### PR TITLE
Update models to match API

### DIFF
--- a/T-Trips/T-Trips/MVVM/Main/AddExpense/AddExpenseView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/AddExpense/AddExpenseView.swift
@@ -43,6 +43,16 @@ final class AddExpenseView: UIView {
         textfield.inputAccessoryView = accessoryToolbar
         return textfield
     }()
+
+    public private(set) lazy var titleTextField: CustomTextField = {
+        let model = TextFieldModel(
+            placeholder: String.addExpenseTitlePlaceholder,
+            state: .name
+        )
+        let textfield = textFieldFactory.makeTextField(with: model)
+        textfield.inputAccessoryView = accessoryToolbar
+        return textfield
+    }()
     
     public private(set) lazy var dateTextField: CustomTextField = {
         let model = TextFieldModel(
@@ -105,6 +115,7 @@ final class AddExpenseView: UIView {
         super.init(frame: frame)
         backgroundColor = .systemBackground
         [
+            titleTextField,
             amountTextField,
             dateTextField,
             categoryTextField,
@@ -120,6 +131,7 @@ final class AddExpenseView: UIView {
         super.init(coder: coder)
         backgroundColor = .systemBackground
         [
+            titleTextField,
             amountTextField,
             dateTextField,
             categoryTextField,
@@ -132,8 +144,13 @@ final class AddExpenseView: UIView {
     }
     
     private func setupConstraints() {
-        amountTextField.snp.makeConstraints { make in
+        titleTextField.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(CGFloat.topInset)
+            make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
+            make.height.equalTo(CGFloat.fieldHeight)
+        }
+        amountTextField.snp.makeConstraints { make in
+            make.top.equalTo(titleTextField.snp.bottom).offset(CGFloat.verticalSpacing)
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
             make.height.equalTo(CGFloat.fieldHeight)
         }
@@ -182,6 +199,7 @@ private extension CGFloat {
 }
 
 private extension String {
+    static let addExpenseTitlePlaceholder = "Название"
     static let addExpenseAmountPlaceholder = "Сумма"
     static let addExpenseCategoryPlaceholder = "Категория"
     static let addExpenseDatePlaceholder = "Дата"

--- a/T-Trips/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
@@ -17,11 +17,11 @@ final class AddExpenseViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
 
     private let categories = Expense.Category.allCases
-    private let payers: [String]
-    private let payees: [String]
+    private let payers: [User]
+    private let payees: [User]
 
     // MARK: - Init
-    init(tripId: UUID, payers: [String] = [], payees: [String] = []) {
+    init(tripId: Int64, payers: [User] = [], payees: [User] = []) {
         self.viewModel = AddExpenseViewModel(tripId: tripId)
         self.payers = payers
         self.payees = payees
@@ -98,6 +98,13 @@ final class AddExpenseViewController: UIViewController {
 
     // MARK: - Actions
     private func setupActions() {
+        addExpenseView.titleTextField.addAction(
+            UIAction { [weak self] _ in
+                self?.viewModel.title = self?.addExpenseView.titleTextField.text ?? ""
+            },
+            for: .editingChanged
+        )
+
         addExpenseView.amountTextField.addAction(
             UIAction { [weak self] _ in
                 self?.viewModel.amount = self?.addExpenseView.amountTextField.text ?? ""
@@ -118,8 +125,9 @@ final class AddExpenseViewController: UIViewController {
         addExpenseView.payerTextField.addAction(
             UIAction { [weak self] _ in
                 let row = self?.addExpenseView.payerPicker.selectedRow(inComponent: 0) ?? 0
-                self?.viewModel.payer = self?.payers[row] ?? ""
-                self?.addExpenseView.payerTextField.text = self?.payers[row]
+                let user = self?.payers[row]
+                self?.viewModel.payerId = user?.id
+                self?.addExpenseView.payerTextField.text = "\(user?.firstName ?? "") \(user?.lastName ?? "")"
             },
             for: .editingDidEnd
         )
@@ -127,8 +135,9 @@ final class AddExpenseViewController: UIViewController {
         addExpenseView.payeeTextField.addAction(
             UIAction { [weak self] _ in
                 let row = self?.addExpenseView.payeePicker.selectedRow(inComponent: 0) ?? 0
-                self?.viewModel.payee = self?.payees[row] ?? ""
-                self?.addExpenseView.payeeTextField.text = self?.payees[row]
+                let user = self?.payees[row]
+                self?.viewModel.payeeId = user?.id
+                self?.addExpenseView.payeeTextField.text = "\(user?.firstName ?? "") \(user?.lastName ?? "")"
             },
             for: .editingDidEnd
         )
@@ -167,9 +176,11 @@ extension AddExpenseViewController: UIPickerViewDataSource, UIPickerViewDelegate
         case addExpenseView.categoryPicker:
             return categories[row].localized
         case addExpenseView.payerPicker:
-            return payers[row]
+            let user = payers[row]
+            return "\(user.firstName) \(user.lastName)"
         case addExpenseView.payeePicker:
-            return payees[row]
+            let user = payees[row]
+            return "\(user.firstName) \(user.lastName)"
         default: return nil
         }
     }

--- a/T-Trips/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
@@ -10,11 +10,12 @@ import Combine
 
 final class AddExpenseViewModel {
     // MARK: - Inputs
+    @Published var title: String = ""
     @Published var amount: String = ""
     @Published var category: String = ""
     @Published var date = Date()
-    @Published var payer: String = ""
-    @Published var payee: String = ""
+    @Published var payerId: Int64?
+    @Published var payeeId: Int64?
 
     // MARK: - Outputs
     @Published private(set) var isAddEnabled = false
@@ -23,16 +24,19 @@ final class AddExpenseViewModel {
     var onAdd: ((Expense) -> Void)?
 
     private var cancellables = Set<AnyCancellable>()
-    private let tripId: UUID
+    private let tripId: Int64
 
-    init(tripId: UUID) {
+    init(tripId: Int64) {
         self.tripId = tripId
-        Publishers.CombineLatest4($amount, $category, $payer, $payee)
-            .map { amount, category, payer, payee in
-                Double(amount) != nil
-                && !category.isEmpty
-                && !payer.isEmpty
-                && !payee.isEmpty
+        Publishers.CombineLatest4($title, $amount, $category, $payerId)
+            .combineLatest($payeeId)
+            .map { combined, payeeId in
+                let (title, amount, category, payerId) = combined
+                return !title.isEmpty &&
+                    Double(amount) != nil &&
+                    !category.isEmpty &&
+                    payerId != nil &&
+                    payeeId != nil
             }
             .receive(on: RunLoop.main)
             .assign(to: \ .isAddEnabled, on: self)
@@ -40,15 +44,20 @@ final class AddExpenseViewModel {
     }
 
     func addExpense() {
-        guard let value = Double(amount) else { return }
+        guard
+            let value = Double(amount),
+            let payerId = payerId,
+            let payeeId = payeeId
+        else { return }
         let expense = Expense(
-            id: UUID(),
+            id: nil,
             tripId: tripId,
+            title: title,
             category: Expense.Category(rawValue: category.uppercased()) ?? .other,
             amount: value,
-            userId: UUID(),
-            description: nil,
-            createdAt: date
+            ownerId: payerId,
+            createdAt: date,
+            paidForUserIds: [payeeId]
         )
         onAdd?(expense)
     }

--- a/T-Trips/T-Trips/MVVM/Main/ExpenseDetail/ExpenseDetailViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/ExpenseDetail/ExpenseDetailViewModel.swift
@@ -15,7 +15,7 @@ final class ExpenseDetailViewModel {
     @Published private(set) var dateText: String
     @Published private(set) var payer: String
     @Published private(set) var payee: String
-    @Published private(set) var description: String?
+    @Published private(set) var title: String
 
     // MARK: - Handlers
     var onEdit: (() -> Void)?
@@ -37,7 +37,7 @@ final class ExpenseDetailViewModel {
         self.dateText = formatter.string(from: expense.createdAt)
         self.payer = payerName
         self.payee = payeeName ?? ""
-        self.description = expense.description
+        self.title = expense.title
     }
 
     func editTapped() {

--- a/T-Trips/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -56,11 +56,11 @@ final class TripViewController: UIViewController {
         )
         viewModel.onAddExpense = { [weak self] in
             guard let self = self else { return }
-            let names = MockData.users.map { "\($0.name) \($0.surname)" }
+            let users = MockData.users
             let addVC = AddExpenseViewController(
                 tripId: self.viewModel.trip.id,
-                payers: names,
-                payees: names
+                payers: users,
+                payees: users
             )
             addVC.onExpenseAdded = { [weak self] expense in
                 self?.viewModel.addExpense(expense)
@@ -119,7 +119,7 @@ extension TripViewController: UITableViewDataSource, UITableViewDelegate {
         // Кто оплатил
         let payerName: String = {
             if let owner = expense.owner {
-                return "\(owner.name) \(owner.surname)"
+                return "\(owner.firstName) \(owner.lastName)"
             }
             return ""
         }()
@@ -127,7 +127,7 @@ extension TripViewController: UITableViewDataSource, UITableViewDelegate {
         // За кого оплачено — список через запятую
         let payeeName: String = {
             let names = expense.paidForUsers
-                .map { "\($0.name) \($0.surname)" }
+                .map { "\($0.firstName) \($0.lastName)" }
             return names.joined(separator: ", ")
         }()
         

--- a/T-Trips/T-Trips/Models/Debt.swift
+++ b/T-Trips/T-Trips/Models/Debt.swift
@@ -8,28 +8,17 @@
 import Foundation
 
 struct Debt: Codable, Identifiable {
-    let id: Int
-    let tripId: Int
-    let userId: UUID
+    let debtId: String
+    let tripId: Int64
+    let fromUserId: Int64
+    let toUserId: Int64
     let amount: Double
-    let status: Status
-    let createdAt: Date
-    let updatedAt: Date?
-
-    enum Status: String, Codable, CaseIterable {
-        case pending = "PENDING"
-        case paid = "PAID"
-        case confirmed = "CONFIRMED"
-        case cancelled = "CANCELLED"
-    }
 
     private enum CodingKeys: String, CodingKey {
-        case id
-        case tripId = "trip_id"
-        case userId = "user_id"
+        case debtId
+        case tripId
+        case fromUserId
+        case toUserId
         case amount
-        case status
-        case createdAt = "created_at"
-        case updatedAt = "updated_at"
     }
 }

--- a/T-Trips/T-Trips/Models/Expense.swift
+++ b/T-Trips/T-Trips/Models/Expense.swift
@@ -22,21 +22,12 @@ struct Expense: Codable, Identifiable {
 
     enum Category: String, Codable, CaseIterable {
         case tickets = "TICKETS"
-        case hotels = "HOTELS"
+        case longing = "LONGING"
         case food = "FOOD"
         case entertainment = "ENTERTAINMENT"
         case insurance = "INSURANCE"
+        case transport = "TRANSPORT"
         case other = "OTHER"
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case tripId = "trip_id"
-        case category
-        case amount
-        case userId = "user_id"
-        case description
-        case createdAt = "created_at"
     }
 }
 
@@ -45,14 +36,16 @@ extension Expense.Category {
         switch self {
         case .tickets:
             return "Билеты"
-        case .hotels:
-            return "Отель"
+        case .longing:
+            return "Проживание"
         case .food:
             return "Еда"
         case .entertainment:
             return "Развлечения"
         case .insurance:
             return "Страховка"
+        case .transport:
+            return "Транспорт"
         case .other:
             return "Другое"
         }

--- a/T-Trips/T-Trips/Models/Notification.swift
+++ b/T-Trips/T-Trips/Models/Notification.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct NotificationItem: Codable, Identifiable {
     let id: Int
-    let userId: Int
-    let tripId: Int?
+    let userId: Int64
+    let tripId: Int64?
     let type: NotificationType
     let message: String
     let status: Status

--- a/T-Trips/T-Trips/Models/Trip.swift
+++ b/T-Trips/T-Trips/Models/Trip.swift
@@ -10,32 +10,20 @@ import Foundation
 // MARK: - Trip Model
 
 struct Trip: Codable, Identifiable {
-    let id: UUID
-    let adminId: UUID
+    let id: Int64
+    let adminId: Int64
     let title: String
     let startDate: Date
-    let endDate: Date?
+    let endDate: Date
     let budget: Double
     let description: String?
     let status: Status
-    let createdAt: Date
+    let participantIds: [Int64]?
 
     enum Status: String, Codable, CaseIterable {
         case planning = "PLANNING"
         case active   = "ACTIVE"
         case completed = "COMPLETED"
-        case cancelled = "CANCELLED"
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case adminId = "admin_id"
-        case title
-        case startDate = "start_date"
-        case endDate = "end_date"
-        case budget
-        case description
-        case status
-        case createdAt = "created_at"
+        case deleted = "DELETED"
     }
 }

--- a/T-Trips/T-Trips/Models/TripParticipant.swift
+++ b/T-Trips/T-Trips/Models/TripParticipant.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct TripParticipant: Codable, Identifiable {
-    let id: UUID
-    let tripId: UUID
-    let userId: UUID
+    let id: Int64
+    let tripId: Int64
+    let userId: Int64
     let status: Status
     let joinedAt: Date
     let leftAt: Date?
@@ -22,12 +22,4 @@ struct TripParticipant: Codable, Identifiable {
         case left = "LEFT"
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case tripId = "trip_id"
-        case userId = "user_id"
-        case status
-        case joinedAt = "joined_at"
-        case leftAt = "left_at"
-    }
 }

--- a/T-Trips/T-Trips/Models/User.swift
+++ b/T-Trips/T-Trips/Models/User.swift
@@ -10,29 +10,33 @@ import Foundation
 // MARK: - User Model
 
 struct User: Codable, Identifiable {
-    let id: UUID
-    let login: String
+    let id: Int64
     let phone: String
-    let password: String
-    let name: String
-    let surname: String
+    let firstName: String
+    let lastName: String
+    let hashPassword: String
     let status: Status
-    let createdAt: Date
+    let role: Role
+    let active: Bool
 
     enum Status: String, Codable, CaseIterable {
         case active = "ACTIVE"
-        case blocked = "BLOCKED"
         case deleted = "DELETED"
+    }
+
+    enum Role: String, Codable, CaseIterable {
+        case user = "USER"
+        case admin = "ADMIN"
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
-        case login
         case phone
-        case password
-        case name
-        case surname
+        case firstName
+        case lastName
+        case hashPassword
         case status
-        case createdAt = "created_at"
+        case role
+        case active
     }
 }

--- a/T-Trips/T-Trips/Utils/Mocks.swift
+++ b/T-Trips/T-Trips/Utils/Mocks.swift
@@ -10,50 +10,49 @@ import Foundation
 // MARK: - Mocks
 enum MockData {
     static let users: [User] = [
-        // swiftlint:disable line_length
-        User(id: UUID(), login: "ivanov", phone: "+79991234567", password: "password123", name: "Иван", surname: "Иванов", status: .active, createdAt: Date()),
-        User(id: UUID(), login: "petrov", phone: "+79997654321", password: "securePass", name: "Пётр", surname: "Петров", status: .blocked, createdAt: Date().addingTimeInterval(-86400)),
-        User(id: UUID(), login: "sidorov", phone: "+79990001122", password: "pass1234", name: "Сидор", surname: "Сидоров", status: .active, createdAt: Date().addingTimeInterval(-172800)),
-        User(id: UUID(), login: "smirnova", phone: "+79993334455", password: "qwerty", name: "Анна", surname: "Смирнова", status: .active, createdAt: Date().addingTimeInterval(-259200)),
-        User(id: UUID(), login: "orlov", phone: "+79992223344", password: "abc123", name: "Олег", surname: "Орлов", status: .deleted, createdAt: Date().addingTimeInterval(-345600)),
-        User(id: UUID(), login: "fedorova", phone: "+79994445566", password: "letmein", name: "Мария", surname: "Фёдорова", status: .active, createdAt: Date().addingTimeInterval(-432000))
+        User(id: 1, phone: "+79991234567", firstName: "Иван", lastName: "Иванов", hashPassword: "password123", status: .active, role: .user, active: true),
+        User(id: 2, phone: "+79997654321", firstName: "Пётр", lastName: "Петров", hashPassword: "securePass", status: .active, role: .user, active: true),
+        User(id: 3, phone: "+79990001122", firstName: "Сидор", lastName: "Сидоров", hashPassword: "pass1234", status: .active, role: .user, active: true),
+        User(id: 4, phone: "+79993334455", firstName: "Анна", lastName: "Смирнова", hashPassword: "qwerty", status: .active, role: .user, active: true),
+        User(id: 5, phone: "+79992223344", firstName: "Олег", lastName: "Орлов", hashPassword: "abc123", status: .deleted, role: .user, active: false),
+        User(id: 6, phone: "+79994445566", firstName: "Мария", lastName: "Фёдорова", hashPassword: "letmein", status: .active, role: .user, active: true)
     ]
 
     static let trips: [Trip] = [
-        Trip(id: UUID(), adminId: users[0].id, title: "Отпуск в Сочи", startDate: Date(), endDate: Calendar.current.date(byAdding: .day, value: 7, to: Date()), budget: 100000, description: "Море и пляж", status: .active, createdAt: Date()),
-        Trip(id: UUID(), adminId: users[2].id, title: "Горное восхождение", startDate: Date().addingTimeInterval(-86400 * 10), endDate: Date().addingTimeInterval(-86400 * 3), budget: 75000, description: "Приключение в горах", status: .completed, createdAt: Date().addingTimeInterval(-86400 * 12)),
-        Trip(id: UUID(), adminId: users[1].id, title: "Бизнес-поездка", startDate: Date().addingTimeInterval(-86400 * 30), endDate: Date().addingTimeInterval(-86400 * 25), budget: 200000, description: "Встречи с партнёрами", status: .planning, createdAt: Date().addingTimeInterval(-86400 * 40))
+        Trip(id: 1, adminId: users[0].id, title: "Отпуск в Сочи", startDate: Date(), endDate: Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date(), budget: 100000, description: "Море и пляж", status: .active, participantIds: [users[0].id, users[1].id, users[2].id]),
+        Trip(id: 2, adminId: users[2].id, title: "Горное восхождение", startDate: Date().addingTimeInterval(-86400 * 10), endDate: Date().addingTimeInterval(-86400 * 3), budget: 75000, description: "Приключение в горах", status: .completed, participantIds: [users[2].id, users[3].id, users[4].id]),
+        Trip(id: 3, adminId: users[1].id, title: "Бизнес-поездка", startDate: Date().addingTimeInterval(-86400 * 30), endDate: Date().addingTimeInterval(-86400 * 25), budget: 200000, description: "Встречи с партнёрами", status: .planning, participantIds: [users[1].id, users[5].id])
     ]
 
     static let participants: [TripParticipant] = [
-        TripParticipant(id: UUID(), tripId: trips[0].id, userId: users[0].id, status: .accepted, joinedAt: Date().addingTimeInterval(-3600), leftAt: nil),
-        TripParticipant(id: UUID(), tripId: trips[0].id, userId: users[1].id, status: .pending, joinedAt: Date().addingTimeInterval(-7200), leftAt: nil),
-        TripParticipant(id: UUID(), tripId: trips[0].id, userId: users[2].id, status: .accepted, joinedAt: Date().addingTimeInterval(-10800), leftAt: nil),
-        TripParticipant(id: UUID(), tripId: trips[1].id, userId: users[3].id, status: .accepted, joinedAt: Date().addingTimeInterval(-86400 * 11), leftAt: Date().addingTimeInterval(-86400 * 3)),
-        TripParticipant(id: UUID(), tripId: trips[1].id, userId: users[4].id, status: .left, joinedAt: Date().addingTimeInterval(-86400 * 9), leftAt: Date().addingTimeInterval(-86400 * 5)),
-        TripParticipant(id: UUID(), tripId: trips[2].id, userId: users[5].id, status: .pending, joinedAt: Date().addingTimeInterval(-86400 * 31), leftAt: nil)
+        TripParticipant(id: 1, tripId: trips[0].id, userId: users[0].id, status: .accepted, joinedAt: Date().addingTimeInterval(-3600), leftAt: nil),
+        TripParticipant(id: 2, tripId: trips[0].id, userId: users[1].id, status: .pending, joinedAt: Date().addingTimeInterval(-7200), leftAt: nil),
+        TripParticipant(id: 3, tripId: trips[0].id, userId: users[2].id, status: .accepted, joinedAt: Date().addingTimeInterval(-10800), leftAt: nil),
+        TripParticipant(id: 4, tripId: trips[1].id, userId: users[3].id, status: .accepted, joinedAt: Date().addingTimeInterval(-86400 * 11), leftAt: Date().addingTimeInterval(-86400 * 3)),
+        TripParticipant(id: 5, tripId: trips[1].id, userId: users[4].id, status: .left, joinedAt: Date().addingTimeInterval(-86400 * 9), leftAt: Date().addingTimeInterval(-86400 * 5)),
+        TripParticipant(id: 6, tripId: trips[2].id, userId: users[5].id, status: .pending, joinedAt: Date().addingTimeInterval(-86400 * 31), leftAt: nil)
     ]
 
     static let expenses: [Expense] = [
-        Expense(id: UUID(), tripId: trips[0].id, category: .food, amount: 2500.75, userId: users[0].id, description: "Ужин в ресторане", createdAt: Date()),
-        Expense(id: UUID(), tripId: trips[0].id, category: .hotels, amount: 5000, userId: users[1].id, description: nil, createdAt: Date().addingTimeInterval(-18000)),
-        Expense(id: UUID(), tripId: trips[0].id, category: .tickets, amount: 15000, userId: users[2].id, description: "Авиа билеты", createdAt: Date().addingTimeInterval(-36000)),
-        Expense(id: UUID(), tripId: trips[0].id, category: .entertainment, amount: 3000, userId: users[0].id, description: "Экскурсия", createdAt: Date().addingTimeInterval(-54000)),
-        Expense(id: UUID(), tripId: trips[1].id, category: .insurance, amount: 2000, userId: users[3].id, description: "Страховка", createdAt: Date().addingTimeInterval(-86400 * 10)),
-        Expense(id: UUID(), tripId: trips[1].id, category: .other, amount: 1200, userId: users[4].id, description: "Мелкие расходы", createdAt: Date().addingTimeInterval(-86400 * 9)),
-        Expense(id: UUID(), tripId: trips[2].id, category: .food, amount: 8000, userId: users[5].id, description: "Деловой обед", createdAt: Date().addingTimeInterval(-86400 * 29))
+        Expense(id: 1, tripId: trips[0].id, title: "Ужин в ресторане", category: .food, amount: 2500.75, ownerId: users[0].id, createdAt: Date(), paidForUserIds: [users[1].id]),
+        Expense(id: 2, tripId: trips[0].id, title: "Отель", category: .longing, amount: 5000, ownerId: users[1].id, createdAt: Date().addingTimeInterval(-18000), paidForUserIds: [users[0].id]),
+        Expense(id: 3, tripId: trips[0].id, title: "Авиа билеты", category: .tickets, amount: 15000, ownerId: users[2].id, createdAt: Date().addingTimeInterval(-36000), paidForUserIds: [users[2].id]),
+        Expense(id: 4, tripId: trips[0].id, title: "Экскурсия", category: .entertainment, amount: 3000, ownerId: users[0].id, createdAt: Date().addingTimeInterval(-54000), paidForUserIds: [users[1].id, users[2].id]),
+        Expense(id: 5, tripId: trips[1].id, title: "Страховка", category: .insurance, amount: 2000, ownerId: users[3].id, createdAt: Date().addingTimeInterval(-86400 * 10), paidForUserIds: [users[3].id]),
+        Expense(id: 6, tripId: trips[1].id, title: "Мелкие расходы", category: .other, amount: 1200, ownerId: users[4].id, createdAt: Date().addingTimeInterval(-86400 * 9), paidForUserIds: [users[4].id]),
+        Expense(id: 7, tripId: trips[2].id, title: "Деловой обед", category: .food, amount: 8000, ownerId: users[5].id, createdAt: Date().addingTimeInterval(-86400 * 29), paidForUserIds: [users[5].id])
     ]
 
     static let debts: [Debt] = [
-        Debt(id: 1, tripId: 1, userId: users[1].id, amount: 1250.37, status: .pending, createdAt: Date(), updatedAt: nil),
-        Debt(id: 2, tripId: 1, userId: users[2].id, amount: 500, status: .confirmed, createdAt: Date().addingTimeInterval(-10000), updatedAt: Date().addingTimeInterval(-5000)),
-        Debt(id: 3, tripId: 2, userId: users[3].id, amount: 300, status: .paid, createdAt: Date().addingTimeInterval(-86400 * 10), updatedAt: Date().addingTimeInterval(-86400 * 5))
+        Debt(debtId: "1", tripId: trips[0].id, fromUserId: users[1].id, toUserId: users[0].id, amount: 1250.37),
+        Debt(debtId: "2", tripId: trips[0].id, fromUserId: users[2].id, toUserId: users[0].id, amount: 500),
+        Debt(debtId: "3", tripId: trips[1].id, fromUserId: users[3].id, toUserId: users[2].id, amount: 300)
     ]
 
     static let notifications: [NotificationItem] = [
-        NotificationItem(id: 1, userId: 1, tripId: trips[0].id.hashValue, type: .invitation, message: "Вас добавили в поездку 'Отпуск в Сочи'", status: .unread, createdAt: Date()),
-        NotificationItem(id: 2, userId: 2, tripId: trips[1].id.hashValue, type: .expenseAdded, message: "Новый расход добавлен", status: .read, createdAt: Date().addingTimeInterval(-20000)),
-        NotificationItem(id: 3, userId: 5, tripId: trips[2].id.hashValue, type: .debtCreated, message: "У вас новый долг", status: .archived, createdAt: Date().addingTimeInterval(-40000))
+        NotificationItem(id: 1, userId: 1, tripId: trips[0].id, type: .invitation, message: "Вас добавили в поездку 'Отпуск в Сочи'", status: .unread, createdAt: Date()),
+        NotificationItem(id: 2, userId: 2, tripId: trips[1].id, type: .expenseAdded, message: "Новый расход добавлен", status: .read, createdAt: Date().addingTimeInterval(-20000)),
+        NotificationItem(id: 3, userId: 5, tripId: trips[2].id, type: .debtCreated, message: "У вас новый долг", status: .archived, createdAt: Date().addingTimeInterval(-40000))
     ]
     // swiftlint:enable line_length
 }


### PR DESCRIPTION
## Summary
- update data models to match API field names and types
- adjust AddExpense flow with new title field and user IDs
- refresh mock data for new models

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b1a4bb2c832c8100628743bceab8