### PR TITLE
Implement mock API service

### DIFF
--- a/T-Trips/MVVM/Auth/AuthViewModel.swift
+++ b/T-Trips/MVVM/Auth/AuthViewModel.swift
@@ -36,8 +36,11 @@ final class AuthViewModel {
 
     // MARK: - Actions
     func login() {
-        // TODO: call API for auth
-        onLoginSuccess?()
+        MockAPIService.shared.authenticate(phone: phone, password: password) { [weak self] success in
+            DispatchQueue.main.async {
+                if success { self?.onLoginSuccess?() }
+            }
+        }
     }
 
     func register() {

--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
@@ -49,16 +49,18 @@ final class AddExpenseViewModel {
             let payerId = payerId,
             let payeeId = payeeId
         else { return }
-        let expense = Expense(
-            id: nil,
-            tripId: tripId,
-            title: title,
+
+        let dto = ExpenseDtoForCreate(
             category: Expense.Category(rawValue: category.uppercased()) ?? .other,
             amount: value,
-            ownerId: payerId,
-            createdAt: date,
+            title: title,
             paidForUserIds: [payeeId]
         )
-        onAdd?(expense)
+
+        MockAPIService.shared.createExpense(tripId: tripId, dto: dto, ownerId: payerId) { [weak self] expense in
+            DispatchQueue.main.async {
+                self?.onAdd?(expense)
+            }
+        }
     }
 }

--- a/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
@@ -1,8 +1,20 @@
 import UIKit
+import Combine
 
 final class DebtsViewController: UIViewController {
     private let debtsView = DebtsView()
-    private let viewModel = DebtsViewModel()
+    private let viewModel: DebtsViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(tripId: Int64, userId: Int64? = nil) {
+        self.viewModel = DebtsViewModel(tripId: tripId, userId: userId)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.viewModel = DebtsViewModel(tripId: 0)
+        super.init(coder: coder)
+    }
 
     override func loadView() {
         view = debtsView
@@ -11,12 +23,22 @@ final class DebtsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Долги"
+        setupBindings()
         setupTable()
     }
 
     private func setupTable() {
         debtsView.tableView.dataSource = self
         debtsView.tableView.delegate = self
+    }
+
+    private func setupBindings() {
+        viewModel.$debts
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.debtsView.tableView.reloadData()
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+import Combine
+
 final class DebtsViewModel {
-    var debts: [Debt] = MockData.debts
+    @Published private(set) var debts: [Debt] = []
+
+    private let tripId: Int64
+    private let userId: Int64?
+
+    init(tripId: Int64, userId: Int64? = nil) {
+        self.tripId = tripId
+        self.userId = userId
+        loadDebts()
+    }
+
+    func loadDebts() {
+        MockAPIService.shared.getDebts(tripId: tripId, userId: userId) { [weak self] debts in
+            DispatchQueue.main.async {
+                self?.debts = debts
+            }
+        }
+    }
 }

--- a/T-Trips/MVVM/Main/Trip/TripViewModel.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewModel.swift
@@ -24,9 +24,11 @@ final class TripViewModel {
 
     // MARK: - Data Loading
     private func loadExpenses() {
-        // TODO: заменить на API
-        self.expenses = MockData.expenses
-            .filter { $0.tripId == trip.id }
+        MockAPIService.shared.getExpenses(tripId: trip.id) { [weak self] expenses in
+            DispatchQueue.main.async {
+                self?.expenses = expenses
+            }
+        }
     }
 
     // MARK: - Actions

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+final class MockAPIService {
+    static let shared = MockAPIService()
+
+    private var trips: [Trip]
+    private var expenses: [Expense]
+    private var debts: [Debt]
+    private var users: [User]
+
+    private init() {
+        self.trips = MockData.trips
+        self.expenses = MockData.expenses
+        self.debts = MockData.debts
+        self.users = MockData.users
+    }
+
+    // MARK: - Trips
+    func getUserTrips(status: Trip.Status, completion: @escaping ([Trip]) -> Void) {
+        asyncDelay {
+            let result = self.trips.filter { $0.status == status }
+            completion(result)
+        }
+    }
+
+    func getTrip(id: Int64, completion: @escaping (Trip?) -> Void) {
+        asyncDelay {
+            completion(self.trips.first { $0.id == id })
+        }
+    }
+
+    func createTrip(_ dto: TripDtoForCreate, adminId: Int64, completion: @escaping (Trip) -> Void) {
+        asyncDelay {
+            let newId = (self.trips.map { $0.id }.max() ?? 0) + 1
+            let trip = Trip(
+                id: newId,
+                adminId: adminId,
+                title: dto.title,
+                startDate: dto.startDate,
+                endDate: dto.endDate,
+                budget: dto.budget,
+                description: dto.description,
+                status: dto.status,
+                participantIds: dto.participantIds
+            )
+            self.trips.append(trip)
+            completion(trip)
+        }
+    }
+
+    // MARK: - Expenses
+    func getExpenses(tripId: Int64, completion: @escaping ([Expense]) -> Void) {
+        asyncDelay {
+            completion(self.expenses.filter { $0.tripId == tripId })
+        }
+    }
+
+    func createExpense(tripId: Int64, dto: ExpenseDtoForCreate, ownerId: Int64, completion: @escaping (Expense) -> Void) {
+        asyncDelay {
+            let newId = (self.expenses.map { $0.id ?? 0 }.max() ?? 0) + 1
+            let expense = Expense(
+                id: newId,
+                tripId: tripId,
+                title: dto.title,
+                category: dto.category,
+                amount: dto.amount,
+                ownerId: ownerId,
+                createdAt: Date(),
+                paidForUserIds: dto.paidForUserIds
+            )
+            self.expenses.append(expense)
+            completion(expense)
+        }
+    }
+
+    func deleteExpense(id: Int64, completion: @escaping () -> Void) {
+        asyncDelay {
+            self.expenses.removeAll { $0.id == id }
+            completion()
+        }
+    }
+
+    // MARK: - Debts
+    func getDebts(tripId: Int64, userId: Int64?, completion: @escaping ([Debt]) -> Void) {
+        asyncDelay {
+            var result = self.debts.filter { $0.tripId == tripId }
+            if let uid = userId {
+                result = result.filter { $0.fromUserId == uid || $0.toUserId == uid }
+            }
+            completion(result)
+        }
+    }
+
+    // MARK: - Participants
+    func findParticipant(phone: String, completion: @escaping (User?) -> Void) {
+        asyncDelay {
+            completion(self.users.first { $0.phone == phone })
+        }
+    }
+
+    // MARK: - Auth
+    func authenticate(phone: String, password: String, completion: @escaping (Bool) -> Void) {
+        asyncDelay {
+            let user = self.users.first { $0.phone == phone && $0.hashPassword == password }
+            completion(user != nil)
+        }
+    }
+}
+
+private extension MockAPIService {
+    func asyncDelay(_ block: @escaping () -> Void) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3, execute: block)
+    }
+}
+
+// MARK: - DTOs
+struct TripDtoForCreate {
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let status: Trip.Status
+    let budget: Double
+    let description: String?
+    let participantIds: [Int64]
+}
+
+struct ExpenseDtoForCreate {
+    let category: Expense.Category
+    let amount: Double
+    let title: String
+    let paidForUserIds: [Int64]
+}


### PR DESCRIPTION
## Summary
- add `MockAPIService` to simulate backend API
- call mock service from Trip and Trips related view models
- create debts service hooks and integrate view controller
- use mock service for adding expenses and authentication
- enable trip creation with DTOs

## Testing
- `swiftc -dump-ast` (fails: no such module 'Combine')

------
https://chatgpt.com/codex/tasks/task_e_68460db6276c832c8bff2212190d959d