### PR TITLE
Fix trip addition and add trip screen menu

### DIFF
--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -2,11 +2,23 @@ import UIKit
 import Combine
 
 final class CreateTripViewController: UIViewController {
+    public var onTripCreated: ((Trip) -> Void)?
+
     private let createView = CreateTripView()
-    private let viewModel = CreateTripViewModel()
+    private let viewModel: CreateTripViewModel
     private var cancellables = Set<AnyCancellable>()
 
     private let participants = MockData.users
+
+    init(adminId: Int64 = 0) {
+        self.viewModel = CreateTripViewModel(adminId: adminId)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.viewModel = CreateTripViewModel()
+        super.init(coder: coder)
+    }
 
     override func loadView() {
         view = createView
@@ -84,8 +96,13 @@ final class CreateTripViewController: UIViewController {
 
         createView.saveButton.addAction(UIAction { [weak self] _ in
             self?.viewModel.saveTrip()
-            self?.navigationController?.popViewController(animated: true)
         }, for: .touchUpInside)
+
+        viewModel.onTripCreated = { [weak self] trip in
+            guard let self = self else { return }
+            self.onTripCreated?(trip)
+            self.navigationController?.popViewController(animated: true)
+        }
     }
 }
 

--- a/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -34,6 +34,7 @@ final class TripViewController: UIViewController {
         if viewModel.trip.status == .completed {
             tripView.addExpenseButton.isHidden = true
         }
+        setupNavigationBar()
         setupBindings()
         setupActions()
         setupTableView()
@@ -75,6 +76,41 @@ final class TripViewController: UIViewController {
         let table = tripView.tableView
         table.dataSource = self
         table.delegate = self
+    }
+
+    // MARK: - Navigation bar
+    private func setupNavigationBar() {
+        let details = UIAction(title: String.detailsTitle) { [weak self] _ in
+            self?.showTripDetails()
+        }
+        let debts = UIAction(title: String.debtsTitle) { [weak self] _ in
+            self?.showDebts()
+        }
+        let exit = UIAction(title: String.exitTitle, attributes: .destructive) { [weak self] _ in
+            self?.exitTrip()
+        }
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "ellipsis"),
+            menu: UIMenu(children: [details, debts, exit])
+        )
+    }
+
+    private func showTripDetails() {
+        let vm = TripDetailViewModel(trip: viewModel.trip, users: MockData.users)
+        let vc = TripDetailViewController(viewModel: vm)
+        vc.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
+    private func showDebts() {
+        let vc = DebtsViewController(tripId: viewModel.trip.id)
+        vc.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
+    private func exitTrip() {
+        navigationController?.popViewController(animated: true)
     }
 }
 
@@ -150,4 +186,7 @@ private extension CGFloat {
 
 private extension String {
     static let tripTitile = "Поездка"
+    static let detailsTitle = "Детали"
+    static let debtsTitle = "Долги"
+    static let exitTitle = "Выйти"
 }

--- a/T-Trips/MVVM/Main/Trips/TripsViewController.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewController.swift
@@ -51,6 +51,16 @@ final class TripsViewController: UIViewController {
             },
             for: .touchUpInside
         )
+
+        viewModel.onAddTrip = { [weak self] in
+            guard let self = self else { return }
+            let createVC = CreateTripViewController()
+            createVC.onTripCreated = { [weak self] trip in
+                self?.viewModel.addTrip(trip)
+            }
+            createVC.hidesBottomBarWhenPushed = true
+            self.navigationController?.pushViewController(createVC, animated: true)
+        }
     }
 
     private func updateFilterSelection() {

--- a/T-Trips/MVVM/Main/Trips/TripsViewModel.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewModel.swift
@@ -27,6 +27,9 @@ final class TripsViewModel {
     @Published private(set) var trips: [Trip] = []
     @Published private(set) var filteredTrips: [Trip] = []
 
+    // Handlers
+    var onAddTrip: (() -> Void)?
+
     private var cancellables = Set<AnyCancellable>()
 
     init() {
@@ -54,7 +57,11 @@ final class TripsViewModel {
         }
     }
 
-    func addTripTapped() { /* TODO */ }
+    func addTripTapped() { onAddTrip?() }
+
+    func addTrip(_ trip: Trip) {
+        trips.append(trip)
+    }
 }
 
 private extension TripsViewModel.Filter {


### PR DESCRIPTION
## Summary
- implement `addTripTapped` and trip adding in `TripsViewModel`
- hook up trip creation flow from `TripsViewController`
- support completion handler in `CreateTripViewController`
- add navigation bar menu in `TripViewController` for trip details, debts and exit actions

## Testing
- `swiftlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461277302c832cb9b9893f30f26f3e