### PR TITLE
Fix taps on participants text field

### DIFF
--- a/T-Trips/CustomViews/ParticipantToken/ParticipantTokenView.swift
+++ b/T-Trips/CustomViews/ParticipantToken/ParticipantTokenView.swift
@@ -1,0 +1,54 @@
+import UIKit
+import SnapKit
+
+final class ParticipantTokenView: UIView {
+    private let nameLabel = UILabel()
+    private let removeButton = UIButton(type: .system)
+    var onRemove: (() -> Void)?
+
+    init(name: String) {
+        super.init(frame: .zero)
+        nameLabel.text = name
+        nameLabel.font = UIFont.systemFont(ofSize: CGFloat.nameFontSize)
+        removeButton.setTitle("\u{2715}", for: .normal)
+        removeButton.titleLabel?.font = UIFont.systemFont(ofSize: CGFloat.nameFontSize, weight: .bold)
+        removeButton.addAction(UIAction { [weak self] _ in
+            self?.onRemove?()
+        }, for: .touchUpInside)
+
+        backgroundColor = .systemGray5
+        layer.cornerRadius = CGFloat.cornerRadius
+        layer.masksToBounds = true
+
+        addSubview(nameLabel)
+        addSubview(removeButton)
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        let local = convert(point, to: removeButton)
+        return removeButton.point(inside: local, with: event)
+    }
+
+    private func setupConstraints() {
+        nameLabel.snp.makeConstraints { make in
+            make.top.bottom.leading.equalToSuperview().inset(CGFloat.contentInset)
+        }
+        removeButton.snp.makeConstraints { make in
+            make.leading.equalTo(nameLabel.snp.trailing).offset(CGFloat.spacing)
+            make.trailing.equalToSuperview().inset(CGFloat.contentInset)
+            make.centerY.equalToSuperview()
+        }
+    }
+}
+
+private extension CGFloat {
+    static let contentInset: CGFloat = 4
+    static let spacing: CGFloat = 4
+    static let nameFontSize: CGFloat = 12
+    static let cornerRadius: CGFloat = 4
+}

--- a/T-Trips/CustomViews/ParticipantToken/TokenWrappingView.swift
+++ b/T-Trips/CustomViews/ParticipantToken/TokenWrappingView.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+final class TokenWrappingView: UIView {
+    var spacing: CGFloat = 4
+    var onHeightChange: (() -> Void)?
+    private var contentHeight: CGFloat = 0
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let maxWidth = bounds.width
+        var origin = CGPoint(x: 0, y: 0)
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews where !subview.isHidden && subview.alpha > 0 {
+            let size = subview.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+            if origin.x > 0 && origin.x + size.width > maxWidth {
+                origin.x = 0
+                origin.y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.frame = CGRect(origin: origin, size: size)
+            origin.x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        let newHeight = origin.y + rowHeight
+        if abs(newHeight - contentHeight) > 0.5 {
+            contentHeight = newHeight
+            invalidateIntrinsicContentSize()
+            onHeightChange?()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: contentHeight)
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        for view in subviews where !view.isHidden && view.alpha > 0 {
+            let local = convert(point, to: view)
+            if view.point(inside: local, with: event) { return true }
+        }
+        return false
+    }
+}

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
@@ -6,6 +6,15 @@ final class CreateTripView: UIView {
     private let buttonFactory = ButtonFactory()
 
     let participantsPicker = UIPickerView()
+    public private(set) lazy var tokensView: TokenWrappingView = {
+        let view = TokenWrappingView()
+        view.spacing = CGFloat.tokenSpacing
+        view.onHeightChange = { [weak self] in
+            self?.updateParticipantsHeight()
+        }
+        return view
+    }()
+    private var participantsHeightConstraint: Constraint?
     public private(set) lazy var startDatePicker: UIDatePicker = {
         let picker = UIDatePicker()
         picker.datePickerMode = .date
@@ -86,6 +95,10 @@ final class CreateTripView: UIView {
         backgroundColor = .systemBackground
         [titleTextField, startDateTextField, endDateTextField, budgetTextField,
          participantsTextField, descriptionTextField, saveButton].forEach(addSubview)
+        participantsTextField.addSubview(tokensView)
+        tokensView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(CGFloat.tokenInset)
+        }
         setupConstraints()
     }
 
@@ -94,6 +107,10 @@ final class CreateTripView: UIView {
         backgroundColor = .systemBackground
         [titleTextField, startDateTextField, endDateTextField, budgetTextField,
          participantsTextField, descriptionTextField, saveButton].forEach(addSubview)
+        participantsTextField.addSubview(tokensView)
+        tokensView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(CGFloat.tokenInset)
+        }
         setupConstraints()
     }
 
@@ -117,7 +134,8 @@ final class CreateTripView: UIView {
         }
         participantsTextField.snp.makeConstraints { make in
             make.top.equalTo(budgetTextField.snp.bottom).offset(CGFloat.verticalSpacing)
-            make.leading.trailing.height.equalTo(titleTextField)
+            make.leading.trailing.equalTo(titleTextField)
+            participantsHeightConstraint = make.height.equalTo(CGFloat.fieldHeight).constraint
         }
         descriptionTextField.snp.makeConstraints { make in
             make.top.equalTo(participantsTextField.snp.bottom).offset(CGFloat.verticalSpacing)
@@ -128,6 +146,13 @@ final class CreateTripView: UIView {
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
             make.height.equalTo(CGFloat.buttonHeight)
         }
+    }
+
+    private func updateParticipantsHeight() {
+        let height = max(tokensView.intrinsicContentSize.height + 2 * CGFloat.tokenInset,
+                         CGFloat.fieldHeight)
+        participantsHeightConstraint?.update(offset: height)
+        layoutIfNeeded()
     }
 
     @objc private func endEditingNow() {
@@ -142,6 +167,8 @@ private extension CGFloat {
     static let fieldHeight: CGFloat = 50
     static let buttonTop: CGFloat = 24
     static let buttonHeight: CGFloat = 50
+    static let tokenSpacing: CGFloat = 4
+    static let tokenInset: CGFloat = 4
 }
 
 private extension String {


### PR DESCRIPTION
## Summary
- update `ParticipantTokenView` so tokens only intercept taps on their remove button
- dynamically size participant tokens using a wrapping view
- grow the participants text field height as tokens wrap
- filter the picker to exclude already selected users

## Testing
- `swift --version`
- `swiftlint` *(fails: command not found)*
- `xcodebuild -list` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6846174861f4832cad268e06c44b83e6