### PR TITLE
Update add expense participants and enable deletion

### DIFF
--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
@@ -36,7 +36,8 @@ final class AddExpenseViewModel {
                     Double(amount) != nil &&
                     !category.isEmpty &&
                     payerId != nil &&
-                    payeeId != nil
+                    payeeId != nil &&
+                    payerId != payeeId
             }
             .receive(on: RunLoop.main)
             .assign(to: \ .isAddEnabled, on: self)
@@ -47,7 +48,8 @@ final class AddExpenseViewModel {
         guard
             let value = Double(amount),
             let payerId = payerId,
-            let payeeId = payeeId
+            let payeeId = payeeId,
+            payerId != payeeId
         else { return }
 
         let dto = ExpenseDtoForCreate(

--- a/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -57,11 +57,11 @@ final class TripViewController: UIViewController {
         )
         viewModel.onAddExpense = { [weak self] in
             guard let self = self else { return }
-            let users = MockData.users
+            let ids = self.viewModel.trip.participantIds ?? []
+            let participants = MockData.users.filter { ids.contains($0.id) }
             let addVC = AddExpenseViewController(
                 tripId: self.viewModel.trip.id,
-                payers: users,
-                payees: users
+                participants: participants
             )
             addVC.onExpenseAdded = { [weak self] expense in
                 self?.viewModel.addExpense(expense)
@@ -176,6 +176,12 @@ extension TripViewController: UITableViewDataSource, UITableViewDelegate {
         let detailVC = ExpenseDetailViewController(viewModel: detailVM)
         detailVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(detailVC, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            viewModel.deleteExpense(at: indexPath.row)
+        }
     }
 }
 

--- a/T-Trips/MVVM/Main/Trip/TripViewModel.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewModel.swift
@@ -40,4 +40,13 @@ final class TripViewModel {
         expenses.append(expense)
     }
 
+    func deleteExpense(at index: Int) {
+        guard expenses.indices.contains(index), let id = expenses[index].id else { return }
+        MockAPIService.shared.deleteExpense(id: id) { [weak self] in
+            DispatchQueue.main.async {
+                self?.expenses.remove(at: index)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- filter participants for payer/payee pickers in AddExpense
- prevent selecting the payer as a payee
- pass trip participants when adding expense
- allow deleting expenses from trip screen

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684713c58f28832c9af01a84b311e07e