### PR TITLE
Add dark theme toggle and screen navigation

### DIFF
--- a/T-Trips/MVVM/Auth/AuthViewController.swift
+++ b/T-Trips/MVVM/Auth/AuthViewController.swift
@@ -57,6 +57,16 @@ final class AuthViewController: UIViewController {
             )
         }
 
+        viewModel.onLoginFailure = { [weak self] in
+            let alert = UIAlertController(
+                title: nil,
+                message: String.invalidCreds,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            self?.present(alert, animated: true)
+        }
+
         viewModel.onRegister = { [weak self] in
             guard let self = self else { return }
             let registerVC = RegisterViewController()
@@ -92,6 +102,7 @@ final class AuthViewController: UIViewController {
 // MARK: - Constants
 private extension String {
     static let authTitle = "Вход"
+    static let invalidCreds = "Неверный телефон или пароль"
 }
 
 private extension Double {

--- a/T-Trips/MVVM/Auth/AuthViewModel.swift
+++ b/T-Trips/MVVM/Auth/AuthViewModel.swift
@@ -19,6 +19,7 @@ final class AuthViewModel {
     // MARK: - Callbacks
     var onLoginSuccess: (() -> Void)?
     var onRegister: (() -> Void)?
+    var onLoginFailure: (() -> Void)?
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -38,7 +39,11 @@ final class AuthViewModel {
     func login() {
         MockAPIService.shared.authenticate(phone: phone, password: password) { [weak self] success in
             DispatchQueue.main.async {
-                if success { self?.onLoginSuccess?() }
+                if success {
+                    self?.onLoginSuccess?()
+                } else {
+                    self?.onLoginFailure?()
+                }
             }
         }
     }

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewController.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewController.swift
@@ -21,5 +21,11 @@ final class DebtDetailViewController: UIViewController {
         super.viewDidLoad()
         title = "Долг"
         detailView.infoLabel.text = viewModel.infoText
+        detailView.confirmButton.addAction(
+            UIAction { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            },
+            for: .touchUpInside
+        )
     }
 }

--- a/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
@@ -60,6 +60,15 @@ extension DebtsViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return .tvRowHeight
     }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let debt = viewModel.debts[indexPath.row]
+        let vm = DebtDetailViewModel(debt: debt)
+        let vc = DebtDetailViewController(viewModel: vm)
+        vc.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(vc, animated: true)
+    }
 }
 
 private extension CGFloat {

--- a/T-Trips/MVVM/Main/Notifications/NotificationsViewController.swift
+++ b/T-Trips/MVVM/Main/Notifications/NotificationsViewController.swift
@@ -46,6 +46,14 @@ extension NotificationsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return .tvRowHeight
     }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let item = viewModel.notifications[indexPath.row]
+        let alert = UIAlertController(title: nil, message: item.message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
 }
 
 private extension CGFloat {

--- a/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
+++ b/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
@@ -44,5 +44,9 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
 
     @objc private func themeChanged(_ sender: UISwitch) {
         viewModel.darkMode = sender.isOn
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let delegate = scene.delegate as? SceneDelegate,
+              let window = delegate.window else { return }
+        window.overrideUserInterfaceStyle = sender.isOn ? .dark : .light
     }
 }

--- a/T-Trips/MVVM/Main/Settings/SettingsViewModel.swift
+++ b/T-Trips/MVVM/Main/Settings/SettingsViewModel.swift
@@ -1,5 +1,10 @@
 import Foundation
 
 final class SettingsViewModel {
-    var darkMode: Bool = false
+    static let darkModeKey = "darkModeEnabled"
+
+    var darkMode: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.darkModeKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.darkModeKey) }
+    }
 }

--- a/T-Trips/SceneDelegate.swift
+++ b/T-Trips/SceneDelegate.swift
@@ -22,6 +22,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let nav = UINavigationController(rootViewController: startVC)
         nav.navigationBar.prefersLargeTitles = true
         window.rootViewController = nav
+        let darkMode = UserDefaults.standard.bool(forKey: SettingsViewModel.darkModeKey)
+        window.overrideUserInterfaceStyle = darkMode ? .dark : .light
         window.makeKeyAndVisible()
         
         self.window = window


### PR DESCRIPTION
## Summary
- show alert on failed login
- implement dark mode toggle and persistence
- push debt and notification details
- set window style on launch

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68471a880780832cb8e475bc6c3ab9d5