### PR TITLE
Adjust cell colors for dark mode

### DIFF
--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -176,6 +176,7 @@ extension CreateTripViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "suggestCell") ?? UITableViewCell(style: .default, reuseIdentifier: "suggestCell")
+        cell.backgroundColor = .secondarySystemBackground
         let user = filteredParticipants[indexPath.row]
         cell.textLabel?.text = "\(user.firstName) \(user.lastName)"
         return cell

--- a/T-Trips/MVVM/Main/CustomCells/CustomTableCell.swift
+++ b/T-Trips/MVVM/Main/CustomCells/CustomTableCell.swift
@@ -21,7 +21,7 @@ final class CustomTableCell: UITableViewCell {
         selectionStyle = .none
         
         // Configure contentView
-        contentView.backgroundColor = .systemBackground
+        contentView.backgroundColor = .secondarySystemBackground
         contentView.layer.cornerRadius = .cornerRadius
         contentView.layer.masksToBounds = true
         

--- a/T-Trips/MVVM/Main/CustomCells/FilterCell.swift
+++ b/T-Trips/MVVM/Main/CustomCells/FilterCell.swift
@@ -15,7 +15,7 @@ final class FilterCell: UICollectionViewCell {
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.backgroundColor = .systemBackground
+        contentView.backgroundColor = .secondarySystemBackground
         contentView.layer.cornerRadius = .cornerRadius
         contentView.layer.masksToBounds = true
 

--- a/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
+++ b/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
@@ -27,6 +27,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell()
+        cell.backgroundColor = .secondarySystemBackground
         if indexPath.section == 0 {
             cell.textLabel?.text = "Редактировать данные"
         } else if indexPath.row == 0 {

--- a/T-Trips/MVVM/Main/Trip/CustomCells/CustomTripCell.swift
+++ b/T-Trips/MVVM/Main/Trip/CustomCells/CustomTripCell.swift
@@ -21,7 +21,7 @@ final class CustomTripCell: UITableViewCell {
         selectionStyle = .none
 
         // Configure contentView
-        contentView.backgroundColor = .systemBackground
+        contentView.backgroundColor = .secondarySystemBackground
         contentView.layer.cornerRadius = .cornerRadius
         contentView.layer.masksToBounds = true
 

--- a/T-Trips/MVVM/Main/Trip/CustomCells/FilterCell.swift
+++ b/T-Trips/MVVM/Main/Trip/CustomCells/FilterCell.swift
@@ -15,7 +15,7 @@ final class FilterCell: UICollectionViewCell {
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.backgroundColor = .systemBackground
+        contentView.backgroundColor = .secondarySystemBackground
         contentView.layer.cornerRadius = .cornerRadius
         contentView.layer.masksToBounds = true
 


### PR DESCRIPTION
## Summary
- tweak default cell background color for better contrast in dark mode
- fix suggestion list cell background color
- adjust settings cells to use secondary background color

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6847204f72bc832c89533015ab65a7fa