### PR TITLE
Fix localization access

### DIFF
--- a/T-Trips/Utils/LocalizationManager.swift
+++ b/T-Trips/Utils/LocalizationManager.swift
@@ -37,8 +37,8 @@ final class LocalizationManager {
 
 private var bundleKey: UInt8 = 0
 
-private extension Bundle {
-    class func setLanguage(_ language: String) {
+extension Bundle {
+    fileprivate class func setLanguage(_ language: String) {
         guard let path = Bundle.main.path(forResource: language, ofType: "lproj"),
               let bundle = Bundle(path: path) else {
             objc_setAssociatedObject(Bundle.main, &bundleKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
## Summary
- update access level for Bundle extension so `localizedBundle` can be accessed from other files

## Testing
- `swiftlint --version` *(fails: command not found)*
- `swiftformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475103e864832cafec0e7191448a91