### PR TITLE
Add admin-only deletion with confirmation

### DIFF
--- a/T-Trips/Localization/en.lproj/Localizable.strings
+++ b/T-Trips/Localization/en.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "payerTitle" = "Paid by";
 "payeeTitle" = "Paid for";
 "confirmButtonTitle" = "Confirm";
+"cancelButtonTitle" = "Cancel";
+"deleteConfirmation" = "Are you sure you want to delete?";
 "tripDetailsTitle" = "Trip Details";
 "participantsTitle" = "Participants";
 "tripDescriptionTitle" = "Description";

--- a/T-Trips/Localization/ru.lproj/Localizable.strings
+++ b/T-Trips/Localization/ru.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "payerTitle" = "Кто оплатил";
 "payeeTitle" = "За кого оплачено";
 "confirmButtonTitle" = "Подтвердить";
+"cancelButtonTitle" = "Отмена";
+"deleteConfirmation" = "Вы уверены, что хотите удалить?";
 "tripDetailsTitle" = "Детали поездки";
 "participantsTitle" = "Участники";
 "tripDescriptionTitle" = "Описание";

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -129,13 +129,24 @@ final class CreateTripViewController: UIViewController {
         let token = ParticipantTokenView(name: "\(user.firstName) \(user.lastName)")
         token.onRemove = { [weak self, weak token] in
             guard let self = self, let token = token else { return }
-            if let index = self.selectedUsers.firstIndex(where: { $0.id == user.id }) {
-                self.selectedUsers.remove(at: index)
-                self.viewModel.participantIds = self.selectedUsers.map { $0.id }
-                token.removeFromSuperview()
-                self.createView.participantsTextField.placeholder = self.selectedUsers.isEmpty ? self.participantsPlaceholder : nil
-                self.createView.tokensView.setNeedsLayout()
-            }
+            let alert = UIAlertController(
+                title: nil,
+                message: String.deleteConfirmation,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: String.cancelTitle, style: .cancel))
+            alert.addAction(
+                UIAlertAction(title: String.confirmButtonTitle, style: .destructive) { _ in
+                    if let index = self.selectedUsers.firstIndex(where: { $0.id == user.id }) {
+                        self.selectedUsers.remove(at: index)
+                        self.viewModel.participantIds = self.selectedUsers.map { $0.id }
+                        token.removeFromSuperview()
+                        self.createView.participantsTextField.placeholder = self.selectedUsers.isEmpty ? self.participantsPlaceholder : nil
+                        self.createView.tokensView.setNeedsLayout()
+                    }
+                }
+            )
+            self.present(alert, animated: true)
         }
         createView.tokensView.addSubview(token)
         createView.tokensView.setNeedsLayout()
@@ -191,4 +202,11 @@ extension CreateTripViewController: UITableViewDataSource, UITableViewDelegate {
         addParticipant(user)
         createView.suggestionsTableView.reloadData()
     }
+}
+
+// MARK: - Constants
+private extension String {
+    static var cancelTitle: String { "cancelButtonTitle".localized }
+    static var deleteConfirmation: String { "deleteConfirmation".localized }
+    static var confirmButtonTitle: String { "confirmButtonTitle".localized }
 }

--- a/T-Trips/MVVM/Main/ExpenseDetail/ExpenseDetailViewController.swift
+++ b/T-Trips/MVVM/Main/ExpenseDetail/ExpenseDetailViewController.swift
@@ -33,6 +33,7 @@ final class ExpenseDetailViewController: UIViewController {
         title = String.detailTitle
         bindViewModel()
         setupActions()
+        detailView.deleteButton.isHidden = !viewModel.isAdmin
     }
 
     private func bindViewModel() {
@@ -74,8 +75,23 @@ final class ExpenseDetailViewController: UIViewController {
 
     private func setupActions() {
         detailView.deleteButton.addAction(
-            UIAction { [weak self] _ in self?.viewModel.deleteTapped() }, for: .touchUpInside
+            UIAction { [weak self] _ in self?.confirmDeletion() }, for: .touchUpInside
         )
+    }
+
+    private func confirmDeletion() {
+        let alert = UIAlertController(
+            title: nil,
+            message: String.deleteConfirmation,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String.cancelTitle, style: .cancel))
+        alert.addAction(
+            UIAlertAction(title: String.confirmButtonTitle, style: .destructive) { [weak self] _ in
+                self?.viewModel.deleteTapped()
+            }
+        )
+        present(alert, animated: true)
     }
 }
 
@@ -84,4 +100,7 @@ private extension String {
     static var detailTitle: String { "expenseDetailTitle".localized }
     static var editButtonTitle: String { "editButtonTitle".localized }
     static var deleteButtonTitle: String { "deleteButtonTitle".localized }
+    static var cancelTitle: String { "cancelButtonTitle".localized }
+    static var deleteConfirmation: String { "deleteConfirmation".localized }
+    static var confirmButtonTitle: String { "confirmButtonTitle".localized }
 }

--- a/T-Trips/MVVM/Main/ExpenseDetail/ExpenseDetailViewModel.swift
+++ b/T-Trips/MVVM/Main/ExpenseDetail/ExpenseDetailViewModel.swift
@@ -16,6 +16,7 @@ final class ExpenseDetailViewModel {
     @Published private(set) var payer: String
     @Published private(set) var payee: String
     @Published private(set) var title: String
+    let isAdmin: Bool
 
     // MARK: - Handlers
     var onEdit: (() -> Void)?
@@ -30,7 +31,8 @@ final class ExpenseDetailViewModel {
     init(
         expense: Expense,
         payerName: String,
-        payeeName: String? = nil
+        payeeName: String? = nil,
+        isAdmin: Bool
     ) {
         self.category = expense.category.localized
         self.amountText = expense.amount.rubleString
@@ -38,6 +40,7 @@ final class ExpenseDetailViewModel {
         self.payer = payerName
         self.payee = payeeName ?? ""
         self.title = expense.title
+        self.isAdmin = isAdmin
     }
 
     func editTapped() {

--- a/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -171,7 +171,8 @@ extension TripViewController: UITableViewDataSource, UITableViewDelegate {
         let detailVM = ExpenseDetailViewModel(
             expense: expense,
             payerName: payerName,
-            payeeName: payeeName
+            payeeName: payeeName,
+            isAdmin: viewModel.isAdmin
         )
         let detailVC = ExpenseDetailViewController(viewModel: detailVM)
         detailVM.onDelete = { [weak self] in
@@ -182,10 +183,29 @@ extension TripViewController: UITableViewDataSource, UITableViewDelegate {
         navigationController?.pushViewController(detailVC, animated: true)
     }
 
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        viewModel.isAdmin
+    }
+
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            viewModel.deleteExpense(at: indexPath.row)
+            confirmDeletion(at: indexPath)
         }
+    }
+
+    private func confirmDeletion(at indexPath: IndexPath) {
+        let alert = UIAlertController(
+            title: nil,
+            message: String.deleteConfirmation,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String.cancelTitle, style: .cancel))
+        alert.addAction(
+            UIAlertAction(title: String.confirmButtonTitle, style: .destructive) { [weak self] _ in
+                self?.viewModel.deleteExpense(at: indexPath.row)
+            }
+        )
+        present(alert, animated: true)
     }
 }
 
@@ -199,4 +219,7 @@ private extension String {
     static var detailsTitle: String { "details".localized }
     static var debtsTitle: String { "debts".localized }
     static var exitTitle: String { "logout".localized }
+    static var cancelTitle: String { "cancelButtonTitle".localized }
+    static var deleteConfirmation: String { "deleteConfirmation".localized }
+    static var confirmButtonTitle: String { "confirmButtonTitle".localized }
 }

--- a/T-Trips/MVVM/Main/Trip/TripViewModel.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewModel.swift
@@ -13,6 +13,10 @@ final class TripViewModel {
     @Published private(set) var expenses: [Expense] = []
     let trip: Trip
 
+    var isAdmin: Bool {
+        MockAPIService.shared.currentUser?.id == trip.adminId
+    }
+
     // MARK: - Handlers
     var onAddExpense: (() -> Void)?
 
@@ -41,6 +45,7 @@ final class TripViewModel {
     }
 
     func deleteExpense(at index: Int) {
+        guard isAdmin else { return }
         guard expenses.indices.contains(index), let id = expenses[index].id else { return }
         MockAPIService.shared.deleteExpense(id: id) { [weak self] in
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- restrict expense removal to trip admins
- hide delete button on expense detail for non-admins
- confirm before removing expenses or participants
- localize new strings for delete confirmations

## Testing
- `swiftlint` *(fails: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_684766896560832ca2a616af5c3884c8