### PR TITLE
Implement debt payment removal

### DIFF
--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewController.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewController.swift
@@ -25,7 +25,7 @@ final class DebtDetailViewController: UIViewController {
         detailView.payButton.isHidden = !viewModel.showsPayButton
         detailView.payButton.addAction(
             UIAction { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.viewModel.payTapped()
             },
             for: .touchUpInside
         )

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
@@ -9,6 +9,8 @@ final class DebtDetailViewModel {
     /// Should pay button be displayed
     let showsPayButton: Bool
 
+    var onPay: (() -> Void)?
+
     init(debt: Debt) {
         let fromUser = MockData.users.first { $0.id == debt.fromUserId }
         let toUser = MockData.users.first { $0.id == debt.toUserId }
@@ -17,5 +19,9 @@ final class DebtDetailViewModel {
         participantsText = "\(fromName) → \(toName)"
         amountText = debt.amount.rubleString
         showsPayButton = MockAPIService.shared.currentUser?.id == debt.fromUserId
+    }
+
+    func payTapped() {
+        onPay?()
     }
 }

--- a/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
@@ -65,6 +65,10 @@ extension DebtsViewController: UITableViewDataSource, UITableViewDelegate {
         let debt = viewModel.debts[indexPath.row]
         let vm = DebtDetailViewModel(debt: debt)
         let vc = DebtDetailViewController(viewModel: vm)
+        vm.onPay = { [weak self] in
+            self?.viewModel.payDebt(at: indexPath.row)
+            self?.navigationController?.popViewController(animated: true)
+        }
         vc.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -21,4 +21,14 @@ final class DebtsViewModel {
             }
         }
     }
+
+    func payDebt(at index: Int) {
+        guard debts.indices.contains(index) else { return }
+        let id = debts[index].debtId
+        MockAPIService.shared.deleteDebt(id: id) { [weak self] in
+            DispatchQueue.main.async {
+                self?.debts.remove(at: index)
+            }
+        }
+    }
 }

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -103,6 +103,13 @@ final class MockAPIService {
         }
     }
 
+    func deleteDebt(id: String, completion: @escaping () -> Void) {
+        asyncDelay {
+            self.debts.removeAll { $0.debtId == id }
+            completion()
+        }
+    }
+
     // MARK: - Participants
     func findParticipant(phone: String, completion: @escaping (User?) -> Void) {
         asyncDelay {


### PR DESCRIPTION
## Summary
- add deletion support to `MockAPIService`
- add `payDebt` handling in debts view model
- trigger debt deletion from debt detail screen
- connect payment action with debt list

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476dc7b348832c86d75b6ba73ec376