### PR TITLE
Restrict debt payment to completed trips

### DIFF
--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
@@ -11,14 +11,14 @@ final class DebtDetailViewModel {
 
     var onPay: (() -> Void)?
 
-    init(debt: Debt) {
+    init(debt: Debt, canPay: Bool) {
         let fromUser = MockData.users.first { $0.id == debt.fromUserId }
         let toUser = MockData.users.first { $0.id == debt.toUserId }
         let fromName = [fromUser?.firstName, fromUser?.lastName].compactMap { $0 }.joined(separator: " ")
         let toName = [toUser?.firstName, toUser?.lastName].compactMap { $0 }.joined(separator: " ")
         participantsText = "\(fromName) → \(toName)"
         amountText = debt.amount.rubleString
-        showsPayButton = MockAPIService.shared.currentUser?.id == debt.fromUserId
+        showsPayButton = canPay && (MockAPIService.shared.currentUser?.id == debt.fromUserId)
     }
 
     func payTapped() {

--- a/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
@@ -67,7 +67,7 @@ extension DebtsViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let debt = viewModel.debts[indexPath.row]
-        let vm = DebtDetailViewModel(debt: debt)
+        let vm = DebtDetailViewModel(debt: debt, canPay: viewModel.isTripCompleted)
         let vc = DebtDetailViewController(viewModel: vm)
         vm.onPay = { [weak self] in
             self?.viewModel.payDebt(at: indexPath.row)

--- a/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -8,10 +8,23 @@ final class DebtsViewModel {
     private let tripId: Int64
     private let userId: Int64?
 
+    private var tripStatus: Trip.Status?
+
+    var isTripCompleted: Bool { tripStatus == .completed }
+
     init(tripId: Int64, userId: Int64? = nil) {
         self.tripId = tripId
         self.userId = userId
-        loadDebts()
+        loadTripStatus()
+    }
+
+    private func loadTripStatus() {
+        MockAPIService.shared.getTrip(id: tripId) { [weak self] trip in
+            DispatchQueue.main.async {
+                self?.tripStatus = trip?.status
+                self?.loadDebts()
+            }
+        }
     }
 
     func loadDebts() {
@@ -23,6 +36,7 @@ final class DebtsViewModel {
     }
 
     func payDebt(at index: Int) {
+        guard isTripCompleted else { return }
         guard debts.indices.contains(index) else { return }
         let id = debts[index].debtId
         MockAPIService.shared.deleteDebt(id: id) { [weak self] in


### PR DESCRIPTION
## Summary
- load trip status in `DebtsViewModel` and expose `isTripCompleted`
- show the Pay button only when the trip is completed
- block debt payoff for active trips

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68477980e984832c91e983424e23ca67