### PR TITLE
Add creditor and trip info on debt payoff screen

### DIFF
--- a/T-Trips/Localization/en.lproj/Localizable.strings
+++ b/T-Trips/Localization/en.lproj/Localizable.strings
@@ -69,3 +69,5 @@
 "payButtonTitle" = "Pay";
 "logoutConfirmation" = "Are you sure you want to logout?";
 "leaveTripConfirmation" = "Are you sure you want to leave this trip?";
+"requisitesTitle" = "Details";
+"tripNameTitle" = "Trip";

--- a/T-Trips/Localization/ru.lproj/Localizable.strings
+++ b/T-Trips/Localization/ru.lproj/Localizable.strings
@@ -69,3 +69,5 @@
 "payButtonTitle" = "Оплатить";
 "logoutConfirmation" = "Вы уверены, что хотите выйти?";
 "leaveTripConfirmation" = "Вы уверены, что хотите выйти из поездки?";
+"requisitesTitle" = "Реквизиты";
+"tripNameTitle" = "Поездка";

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailView.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailView.swift
@@ -2,8 +2,24 @@ import UIKit
 import SnapKit
 
 final class DebtDetailView: UIView {
-    let participantsLabel = UILabel()
+    let creditorLabel = UILabel()
     let amountLabel = UILabel()
+    let requisitesTitleLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.text = String.requisitesTitle
+        lbl.font = .systemFont(ofSize: CGFloat.titleFont, weight: .regular)
+        lbl.textColor = UIColor.label.withAlphaComponent(CGFloat.titleAlpha)
+        return lbl
+    }()
+    let requisitesLabel = UILabel()
+    let tripTitleLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.text = String.tripNameTitle
+        lbl.font = .systemFont(ofSize: CGFloat.titleFont, weight: .regular)
+        lbl.textColor = UIColor.label.withAlphaComponent(CGFloat.titleAlpha)
+        return lbl
+    }()
+    let tripLabel = UILabel()
     let payButton: CustomButton = {
         let button = CustomButton()
         let model = ButtonFactory().makeConfiguration(title: "payButtonTitle".localized, state: .primary, isEnabled: true) { }
@@ -14,36 +30,60 @@ final class DebtDetailView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .systemBackground
-        [participantsLabel, amountLabel, payButton].forEach(addSubview)
-        participantsLabel.numberOfLines = 0
-        participantsLabel.font = .systemFont(ofSize: CGFloat.participantsFont, weight: .medium)
+        [creditorLabel, amountLabel, requisitesTitleLabel, requisitesLabel, tripTitleLabel, tripLabel, payButton].forEach(addSubview)
+        creditorLabel.numberOfLines = 0
+        creditorLabel.font = .systemFont(ofSize: CGFloat.creditorFont, weight: .medium)
         amountLabel.font = .systemFont(ofSize: CGFloat.amountFont, weight: .bold)
         amountLabel.textColor = .amountColor
+        requisitesLabel.font = .systemFont(ofSize: CGFloat.infoFont, weight: .regular)
+        requisitesLabel.numberOfLines = 0
+        tripLabel.font = .systemFont(ofSize: CGFloat.infoFont, weight: .regular)
+        tripLabel.numberOfLines = 0
         setupConstraints()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         backgroundColor = .systemBackground
-        [participantsLabel, amountLabel, payButton].forEach(addSubview)
-        participantsLabel.numberOfLines = 0
-        participantsLabel.font = .systemFont(ofSize: CGFloat.participantsFont, weight: .medium)
+        [creditorLabel, amountLabel, requisitesTitleLabel, requisitesLabel, tripTitleLabel, tripLabel, payButton].forEach(addSubview)
+        creditorLabel.numberOfLines = 0
+        creditorLabel.font = .systemFont(ofSize: CGFloat.creditorFont, weight: .medium)
         amountLabel.font = .systemFont(ofSize: CGFloat.amountFont, weight: .bold)
         amountLabel.textColor = .amountColor
+        requisitesLabel.font = .systemFont(ofSize: CGFloat.infoFont, weight: .regular)
+        requisitesLabel.numberOfLines = 0
+        tripLabel.font = .systemFont(ofSize: CGFloat.infoFont, weight: .regular)
+        tripLabel.numberOfLines = 0
         setupConstraints()
     }
 
     private func setupConstraints() {
-        participantsLabel.snp.makeConstraints { make in
+        creditorLabel.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(CGFloat.topInset)
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
         }
         amountLabel.snp.makeConstraints { make in
-            make.top.equalTo(participantsLabel.snp.bottom).offset(CGFloat.spacing)
-            make.leading.trailing.equalTo(participantsLabel)
+            make.top.equalTo(creditorLabel.snp.bottom).offset(CGFloat.spacing)
+            make.leading.trailing.equalTo(creditorLabel)
+        }
+        requisitesTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(amountLabel.snp.bottom).offset(CGFloat.sectionSpacing)
+            make.leading.trailing.equalTo(creditorLabel)
+        }
+        requisitesLabel.snp.makeConstraints { make in
+            make.top.equalTo(requisitesTitleLabel.snp.bottom).offset(CGFloat.spacing)
+            make.leading.trailing.equalTo(creditorLabel)
+        }
+        tripTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(requisitesLabel.snp.bottom).offset(CGFloat.sectionSpacing)
+            make.leading.trailing.equalTo(creditorLabel)
+        }
+        tripLabel.snp.makeConstraints { make in
+            make.top.equalTo(tripTitleLabel.snp.bottom).offset(CGFloat.spacing)
+            make.leading.trailing.equalTo(creditorLabel)
         }
         payButton.snp.makeConstraints { make in
-            make.top.equalTo(amountLabel.snp.bottom).offset(CGFloat.buttonTop)
+            make.top.equalTo(tripLabel.snp.bottom).offset(CGFloat.buttonTop)
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
             make.height.equalTo(CGFloat.buttonHeight)
         }
@@ -53,13 +93,22 @@ final class DebtDetailView: UIView {
 private extension CGFloat {
     static let topInset: CGFloat = 24
     static let horizontalInset: CGFloat = 20
+    static let sectionSpacing: CGFloat = 16
     static let spacing: CGFloat = 8
     static let buttonTop: CGFloat = 24
     static let buttonHeight: CGFloat = 50
-    static let participantsFont: CGFloat = 20
+    static let creditorFont: CGFloat = 20
     static let amountFont: CGFloat = 28
+    static let infoFont: CGFloat = 16
+    static let titleFont: CGFloat = 12
+    static let titleAlpha: CGFloat = 0.6
 }
 
 private extension UIColor {
     static let amountColor = UIColor.systemBlue
+}
+
+private extension String {
+    static var requisitesTitle: String { "requisitesTitle".localized }
+    static var tripNameTitle: String { "tripNameTitle".localized }
 }

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewController.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewController.swift
@@ -20,8 +20,10 @@ final class DebtDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Долг"
-        detailView.participantsLabel.text = viewModel.participantsText
+        detailView.creditorLabel.text = viewModel.creditorName
         detailView.amountLabel.text = viewModel.amountText
+        detailView.requisitesLabel.text = viewModel.creditorPhone
+        detailView.tripLabel.text = viewModel.tripTitle
         detailView.payButton.isHidden = !viewModel.showsPayButton
         detailView.payButton.addAction(
             UIAction { [weak self] _ in

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
@@ -2,8 +2,12 @@ import Foundation
 
 /// View model for the debt detail screen
 final class DebtDetailViewModel {
-    /// Text with participants (debtor -> creditor)
-    let participantsText: String
+    /// Creditor full name
+    let creditorName: String
+    /// Creditor phone or requisites
+    let creditorPhone: String
+    /// Trip title
+    let tripTitle: String
     /// Text with amount value
     let amountText: String
     /// Should pay button be displayed
@@ -12,11 +16,14 @@ final class DebtDetailViewModel {
     var onPay: (() -> Void)?
 
     init(debt: Debt, canPay: Bool) {
-        let fromUser = MockData.users.first { $0.id == debt.fromUserId }
-        let toUser = MockData.users.first { $0.id == debt.toUserId }
-        let fromName = [fromUser?.firstName, fromUser?.lastName].compactMap { $0 }.joined(separator: " ")
-        let toName = [toUser?.firstName, toUser?.lastName].compactMap { $0 }.joined(separator: " ")
-        participantsText = "\(fromName) → \(toName)"
+        let creditor = MockData.users.first { $0.id == debt.toUserId }
+        let trip = MockData.trips.first { $0.id == debt.tripId }
+
+        creditorName = [creditor?.firstName, creditor?.lastName]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        creditorPhone = creditor?.phone ?? ""
+        tripTitle = trip?.title ?? ""
         amountText = debt.amount.rubleString
         showsPayButton = canPay && (MockAPIService.shared.currentUser?.id == debt.fromUserId)
     }


### PR DESCRIPTION
## Summary
- show creditor name, payment details and trip name on debt payoff screen
- localize new field titles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68477b4102f4832cb11f83d58235892e