### PR TITLE
Add trip header and category icons

### DIFF
--- a/T-Trips/MVVM/Main/CustomCells/CustomTableCell.swift
+++ b/T-Trips/MVVM/Main/CustomCells/CustomTableCell.swift
@@ -11,6 +11,7 @@ import SnapKit
 final class CustomTableCell: UITableViewCell {
     static let reuseId = String.reuseId
     
+    private let iconView = UIImageView()
     private let titleLabel = UILabel()
     private let dateLabel = UILabel()
     
@@ -32,8 +33,10 @@ final class CustomTableCell: UITableViewCell {
         layer.shadowRadius = .shadowRadius
         layer.masksToBounds = false
         
-        contentView.addSubview(titleLabel)
-        contentView.addSubview(dateLabel)
+        [iconView, titleLabel, dateLabel].forEach { contentView.addSubview($0) }
+
+        iconView.tintColor = .label
+        iconView.contentMode = .scaleAspectFit
         
         // Label styles
         titleLabel.font = .systemFont(ofSize: .titleFontSize, weight: .medium)
@@ -42,16 +45,20 @@ final class CustomTableCell: UITableViewCell {
         dateLabel.textColor = UIColor.dateTextColor
         
         // Constraints
+        iconView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(CGFloat.sideInset)
+            make.centerY.equalTo(titleLabel)
+            make.width.height.equalTo(CGFloat.iconSize)
+        }
         titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(CGFloat.topInset)
-            make.leading.equalToSuperview().offset(CGFloat.sideInset)
+            make.leading.equalTo(iconView.snp.trailing).offset(CGFloat.iconSpacing)
             make.trailing.equalToSuperview().inset(CGFloat.sideInset)
         }
         dateLabel.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(CGFloat.labelSpacing)
             make.leading.trailing.equalTo(titleLabel)
-            make.bottom.equalToSuperview().inset(
-                CGFloat.bottomInset)
+            make.bottom.equalToSuperview().inset(CGFloat.bottomInset)
         }
     }
     
@@ -71,26 +78,45 @@ final class CustomTableCell: UITableViewCell {
     
     // MARK: - Configure for Trip
     func configure(with trip: Trip) {
+        iconView.isHidden = true
         titleLabel.text = trip.title
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         let start = formatter.string(from: trip.startDate)
         let end = formatter.string(from: trip.endDate)
         dateLabel.text = "\(start) - \(end)"
+        titleLabel.snp.remakeConstraints { make in
+            make.top.equalToSuperview().offset(CGFloat.topInset)
+            make.leading.equalToSuperview().offset(CGFloat.sideInset)
+            make.trailing.equalToSuperview().inset(CGFloat.sideInset)
+        }
     }
 
     // MARK: - Configure for Expense
     func configure(with expense: Expense) {
+        iconView.isHidden = false
+        iconView.image = UIImage(systemName: expense.category.symbolName)
         let amountString = expense.amount.rubleString
         let categoryString = expense.category.localized
         titleLabel.text = "\(amountString)"
         dateLabel.text = "\(categoryString)"
+        titleLabel.snp.remakeConstraints { make in
+            make.top.equalToSuperview().offset(CGFloat.topInset)
+            make.leading.equalTo(iconView.snp.trailing).offset(CGFloat.iconSpacing)
+            make.trailing.equalToSuperview().inset(CGFloat.sideInset)
+        }
     }
 
     // MARK: - Configure with plain text
     func configure(with text: String) {
+        iconView.isHidden = true
         titleLabel.text = text
         dateLabel.text = nil
+        titleLabel.snp.remakeConstraints { make in
+            make.top.equalToSuperview().offset(CGFloat.topInset)
+            make.leading.equalToSuperview().offset(CGFloat.sideInset)
+            make.trailing.equalToSuperview().inset(CGFloat.sideInset)
+        }
     }
 }
 
@@ -102,6 +128,8 @@ private extension CGFloat {
     static let bottomInset: CGFloat = 16
     static let sideInset: CGFloat = 16
     static let labelSpacing: CGFloat = 8
+    static let iconSize: CGFloat = 24
+    static let iconSpacing: CGFloat = 8
     static let titleFontSize: CGFloat = 16
     static let dateFontSize: CGFloat = 14
 }

--- a/T-Trips/MVVM/Main/Trip/TripView.swift
+++ b/T-Trips/MVVM/Main/Trip/TripView.swift
@@ -10,6 +10,12 @@ import SnapKit
 
 final class TripView: UIView {
     // MARK: - UI Components
+    let headerLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.font = .systemFont(ofSize: CGFloat.headerFont, weight: .bold)
+        lbl.textAlignment = .center
+        return lbl
+    }()
     let tableView: UITableView = {
         let table = UITableView()
         table.register(CustomTableCell.self, forCellReuseIdentifier: CustomTableCell.reuseId)
@@ -34,20 +40,25 @@ final class TripView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .systemBackground
-        [tableView, addExpenseButton].forEach(addSubview)
+        [headerLabel, tableView, addExpenseButton].forEach(addSubview)
         setupConstraints()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         backgroundColor = .systemBackground
-        [tableView, addExpenseButton].forEach(addSubview)
+        [headerLabel, tableView, addExpenseButton].forEach(addSubview)
         setupConstraints()
     }
 
     private func setupConstraints() {
+        headerLabel.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(CGFloat.headerTopInset)
+            make.leading.trailing.equalToSuperview().inset(CGFloat.headerSideInset)
+        }
         tableView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.top.equalTo(headerLabel.snp.bottom).offset(CGFloat.tableTopInset)
+            make.leading.trailing.bottom.equalToSuperview()
         }
         addExpenseButton.snp.makeConstraints { make in
             make.width.height.equalTo(CGFloat.tripAddButtonSize)
@@ -62,6 +73,10 @@ private extension CGFloat {
     static let tripAddButtonSize: CGFloat   = 55
     static let tripHorizontalInset: CGFloat = 16
     static let tripVerticalInset: CGFloat   = 16
+    static let headerTopInset: CGFloat      = 16
+    static let headerSideInset: CGFloat     = 16
+    static let headerFont: CGFloat          = 24
+    static let tableTopInset: CGFloat       = 8
 }
 
 private extension String {

--- a/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -31,6 +31,7 @@ final class TripViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = .tripTitile
+        tripView.headerLabel.text = viewModel.trip.title.uppercased()
         if viewModel.trip.status == .completed {
             tripView.addExpenseButton.isHidden = true
         }

--- a/T-Trips/Models/Expense.swift
+++ b/T-Trips/Models/Expense.swift
@@ -50,4 +50,24 @@ extension Expense.Category {
             return "other".localized
         }
     }
+
+    /// SF Symbol name associated with the expense category
+    var symbolName: String {
+        switch self {
+        case .tickets:
+            return "ticket.fill"
+        case .longing:
+            return "bed.double.fill"
+        case .food:
+            return "fork.knife"
+        case .entertainment:
+            return "gamecontroller.fill"
+        case .insurance:
+            return "shield.fill"
+        case .transport:
+            return "car.fill"
+        case .other:
+            return "ellipsis.circle"
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- show icons for each expense category using SF Symbols
- add a header label at the top of the trip screen
- display the trip name in uppercase within the header

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477e490fa0832c9cbc04f0475133b8