### PR TITLE
Add custom screen headers and update trip details

### DIFF
--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseView.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseView.swift
@@ -11,6 +11,14 @@ import SnapKit
 final class AddExpenseView: UIView {
     // MARK: - Factories
     private let textFieldFactory = TextFieldFactory()
+
+    let headerLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.font = .systemFont(ofSize: CGFloat.headerFontSize, weight: .bold)
+        lbl.textAlignment = .left
+        lbl.text = "addExpenseTitle".localized
+        return lbl
+    }()
     
     // MARK: - Pickers & Input Views
     let categoryPicker = UIPickerView()
@@ -130,6 +138,7 @@ final class AddExpenseView: UIView {
         super.init(frame: frame)
         backgroundColor = .systemBackground
         [
+            headerLabel,
             titleTextField,
             amountTextField,
             dateTextField,
@@ -149,6 +158,7 @@ final class AddExpenseView: UIView {
         super.init(coder: coder)
         backgroundColor = .systemBackground
         [
+            headerLabel,
             titleTextField,
             amountTextField,
             dateTextField,
@@ -165,9 +175,13 @@ final class AddExpenseView: UIView {
     }
     
     private func setupConstraints() {
-        titleTextField.snp.makeConstraints { make in
+        headerLabel.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(CGFloat.topInset)
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
+        }
+        titleTextField.snp.makeConstraints { make in
+            make.top.equalTo(headerLabel.snp.bottom).offset(CGFloat.verticalSpacing)
+            make.leading.trailing.equalTo(headerLabel)
             make.height.equalTo(CGFloat.fieldHeight)
         }
         amountTextField.snp.makeConstraints { make in
@@ -226,6 +240,7 @@ final class AddExpenseView: UIView {
 // MARK: - Constants
 private extension CGFloat {
     static let topInset: CGFloat = 24
+    static let headerFontSize: CGFloat = 28
     static let horizontalInset: CGFloat = 20
     static let fieldHeight: CGFloat = 50
     static let verticalSpacing: CGFloat = 16

--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
@@ -48,7 +48,7 @@ final class AddExpenseViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "addExpenseTitle".localized
+        navigationItem.title = nil
         setupBindings()
         setupPickers()
         setupSuggestions()

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
@@ -5,6 +5,14 @@ final class CreateTripView: UIView {
     private let textFieldFactory = TextFieldFactory()
     private let buttonFactory = ButtonFactory()
 
+    let headerLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.font = .systemFont(ofSize: CGFloat.headerFontSize, weight: .bold)
+        lbl.textAlignment = .left
+        lbl.text = "createTripTitle".localized
+        return lbl
+    }()
+
     let suggestionsTableView: UITableView = {
         let table = UITableView()
         table.isHidden = true
@@ -112,7 +120,7 @@ final class CreateTripView: UIView {
      override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .systemBackground
-        [titleTextField, datesStackView, budgetTextField,
+        [headerLabel, titleTextField, datesStackView, budgetTextField,
         participantsTextField, tokensView, suggestionsTableView, descriptionTextView, saveButton].forEach(addSubview)
         tokensView.trailingSpace = CGFloat.inputSpace
         setupConstraints()
@@ -121,16 +129,20 @@ final class CreateTripView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         backgroundColor = .systemBackground
-        [titleTextField, datesStackView, budgetTextField,
+        [headerLabel, titleTextField, datesStackView, budgetTextField,
         participantsTextField, tokensView, suggestionsTableView, descriptionTextView, saveButton].forEach(addSubview)
         tokensView.trailingSpace = CGFloat.inputSpace
         setupConstraints()
     }
 
     private func setupConstraints() {
-        titleTextField.snp.makeConstraints { make in
+        headerLabel.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(CGFloat.topInset)
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
+        }
+        titleTextField.snp.makeConstraints { make in
+            make.top.equalTo(headerLabel.snp.bottom).offset(CGFloat.verticalSpacing)
+            make.leading.trailing.equalTo(headerLabel)
             make.height.equalTo(CGFloat.fieldHeight)
         }
         datesStackView.snp.makeConstraints { make in
@@ -185,6 +197,7 @@ final class CreateTripView: UIView {
 
 private extension CGFloat {
     static let topInset: CGFloat = 24
+    static let headerFontSize: CGFloat = 28
     static let horizontalInset: CGFloat = 20
     static let verticalSpacing: CGFloat = 16
     static let fieldHeight: CGFloat = 50

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -34,7 +34,7 @@ final class CreateTripViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "createTripTitle".localized
+        navigationItem.title = nil
         setupBindings()
         setupPickers()
         setupSuggestions()

--- a/T-Trips/MVVM/Main/TripDetail/TripDetailView.swift
+++ b/T-Trips/MVVM/Main/TripDetail/TripDetailView.swift
@@ -3,7 +3,13 @@ import SnapKit
 
 final class TripDetailView: UIView {
     // MARK: - UI Components
-    private let containerView = UIView()
+    let headerLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.font = .systemFont(ofSize: CGFloat.headerFontSize, weight: .bold)
+        lbl.textAlignment = .left
+        lbl.text = "tripDetailsTitle".localized
+        return lbl
+    }()
 
     let titleLabel = UILabel()
     let startLabel = UILabel()
@@ -37,10 +43,9 @@ final class TripDetailView: UIView {
         super.init(frame: frame)
         backgroundColor = .systemBackground
 
-        addSubview(containerView)
-        [titleLabel, datesStackView, budgetLabel,
+        [headerLabel, titleLabel, datesStackView, budgetLabel,
          participantsTitleLabel, participantsLabel,
-         descriptionTitleLabel, descriptionLabel].forEach(containerView.addSubview)
+         descriptionTitleLabel, descriptionLabel].forEach(addSubview)
 
         setupUI()
         setupConstraints()
@@ -50,23 +55,22 @@ final class TripDetailView: UIView {
         super.init(coder: coder)
         backgroundColor = .systemBackground
 
-        addSubview(containerView)
-        [titleLabel, datesStackView, budgetLabel,
+        [headerLabel, titleLabel, datesStackView, budgetLabel,
          participantsTitleLabel, participantsLabel,
-         descriptionTitleLabel, descriptionLabel].forEach(containerView.addSubview)
+         descriptionTitleLabel, descriptionLabel].forEach(addSubview)
 
         setupUI()
         setupConstraints()
     }
 
     private func setupConstraints() {
-        containerView.snp.makeConstraints { make in
-            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets.contentInset)
-        }
-
-        titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(CGFloat.topInset)
+        headerLabel.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(CGFloat.topInset)
             make.leading.trailing.equalToSuperview().inset(CGFloat.horizontalInset)
+        }
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(headerLabel.snp.bottom).offset(CGFloat.sectionSpacing)
+            make.leading.trailing.equalTo(headerLabel)
         }
         datesStackView.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(CGFloat.sectionSpacing)
@@ -95,15 +99,9 @@ final class TripDetailView: UIView {
     }
 
     private func setupUI() {
-        containerView.backgroundColor = .secondarySystemBackground
-        containerView.layer.cornerRadius = CGFloat.cornerRadius
-        containerView.layer.masksToBounds = true
+        backgroundColor = .systemBackground
 
-        layer.shadowColor = UIColor.shadowColor
-        layer.shadowOpacity = Float.shadowOpacity
-        layer.shadowOffset = .shadowOffset
-        layer.shadowRadius = .shadowRadius
-        layer.masksToBounds = false
+        headerLabel.numberOfLines = 0
 
         titleLabel.font = .systemFont(ofSize: CGFloat.titleFontSize, weight: .bold)
         titleLabel.numberOfLines = 0
@@ -130,10 +128,6 @@ final class TripDetailView: UIView {
         descriptionLabel.numberOfLines = 0
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        layer.shadowPath = UIBezierPath(roundedRect: containerView.frame, cornerRadius: containerView.layer.cornerRadius).cgPath
-    }
 }
 
 private extension CGFloat {
@@ -146,24 +140,7 @@ private extension CGFloat {
     static let budgetFontSize: CGFloat = 18
     static let detailFontSize: CGFloat = 14
     static let smallTitleFontSize: CGFloat = 12
-    static let cornerRadius: CGFloat = 12
-    static let shadowRadius: CGFloat = 4
     static let titleAlpha: CGFloat = 0.6
     static let datesSpacing: CGFloat = 8
-}
-
-private extension UIEdgeInsets {
-    static let contentInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-}
-
-private extension CGSize {
-    static let shadowOffset = CGSize(width: 0, height: 2)
-}
-
-private extension UIColor {
-    static let shadowColor = UIColor.black.cgColor
-}
-
-private extension Float {
-    static let shadowOpacity: Float = 0.1
+    static let headerFontSize: CGFloat = 28
 }

--- a/T-Trips/MVVM/Main/TripDetail/TripDetailViewController.swift
+++ b/T-Trips/MVVM/Main/TripDetail/TripDetailViewController.swift
@@ -21,7 +21,7 @@ final class TripDetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "tripDetailsTitle".localized
+        navigationItem.title = nil
         bind()
     }
 


### PR DESCRIPTION
## Summary
- add left-aligned header labels to Create Trip and Add Expense views
- update Trip Detail view layout to mimic Create Trip style
- hide navigation bar titles for edited screens

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684783789030832c856a2357b2f378e6