### PR TITLE
Implement invitation notifications

### DIFF
--- a/T-Trips/Localization/en.lproj/Localizable.strings
+++ b/T-Trips/Localization/en.lproj/Localizable.strings
@@ -71,3 +71,5 @@
 "leaveTripConfirmation" = "Are you sure you want to leave this trip?";
 "requisitesTitle" = "Details";
 "tripNameTitle" = "Trip";
+"acceptButtonTitle" = "Accept";
+"rejectButtonTitle" = "Reject";

--- a/T-Trips/Localization/ru.lproj/Localizable.strings
+++ b/T-Trips/Localization/ru.lproj/Localizable.strings
@@ -71,3 +71,5 @@
 "leaveTripConfirmation" = "Вы уверены, что хотите выйти из поездки?";
 "requisitesTitle" = "Реквизиты";
 "tripNameTitle" = "Поездка";
+"acceptButtonTitle" = "Принять";
+"rejectButtonTitle" = "Отклонить";

--- a/T-Trips/MVVM/Main/Notifications/InvitationCell.swift
+++ b/T-Trips/MVVM/Main/Notifications/InvitationCell.swift
@@ -1,0 +1,103 @@
+import UIKit
+import SnapKit
+
+final class InvitationCell: UITableViewCell {
+    static let reuseId = "InvitationCell"
+
+    private let messageLabel = UILabel()
+    private let acceptButton = CustomButton()
+    private let rejectButton = CustomButton()
+
+    var onAccept: (() -> Void)?
+    var onReject: (() -> Void)?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
+        selectionStyle = .none
+
+        contentView.backgroundColor = .secondarySystemBackground
+        contentView.layer.cornerRadius = CGFloat.cornerRadius
+        contentView.layer.masksToBounds = true
+
+        layer.shadowColor = UIColor.shadowColor
+        layer.shadowOpacity = Float.shadowOpacity
+        layer.shadowOffset = CGSize.shadowOffset
+        layer.shadowRadius = CGFloat.shadowRadius
+        layer.masksToBounds = false
+
+        [messageLabel, acceptButton, rejectButton].forEach { contentView.addSubview($0) }
+
+        messageLabel.numberOfLines = 0
+        messageLabel.font = .systemFont(ofSize: CGFloat.fontSize)
+
+        let acceptModel = ButtonModel(title: String.accept, state: .primary, isEnabled: true) { [weak self] in
+            self?.onAccept?()
+        }
+        acceptButton.configure(with: acceptModel)
+
+        let rejectModel = ButtonModel(title: String.reject, state: .secondary, isEnabled: true) { [weak self] in
+            self?.onReject?()
+        }
+        rejectButton.configure(with: rejectModel)
+
+        messageLabel.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview().inset(CGFloat.sideInset)
+        }
+        acceptButton.snp.makeConstraints { make in
+            make.top.equalTo(messageLabel.snp.bottom).offset(CGFloat.buttonSpacing)
+            make.leading.equalToSuperview().offset(CGFloat.sideInset)
+            make.bottom.equalToSuperview().inset(CGFloat.sideInset)
+        }
+        rejectButton.snp.makeConstraints { make in
+            make.top.equalTo(acceptButton)
+            make.leading.equalTo(acceptButton.snp.trailing).offset(CGFloat.buttonSpacing)
+            make.trailing.equalToSuperview().inset(CGFloat.sideInset)
+            make.width.equalTo(acceptButton)
+            make.bottom.equalTo(acceptButton)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets.contentInset)
+        layer.shadowPath = UIBezierPath(roundedRect: contentView.frame, cornerRadius: contentView.layer.cornerRadius).cgPath
+    }
+
+    func configure(message: String) {
+        messageLabel.text = message
+    }
+}
+
+private extension CGFloat {
+    static let cornerRadius: CGFloat = 12
+    static let shadowRadius: CGFloat = 4
+    static let sideInset: CGFloat = 16
+    static let buttonSpacing: CGFloat = 12
+    static let fontSize: CGFloat = 16
+}
+
+private extension Float {
+    static let shadowOpacity: Float = 0.1
+}
+
+private extension CGSize {
+    static let shadowOffset = CGSize(width: 0, height: 2)
+}
+
+private extension UIEdgeInsets {
+    static let contentInset = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+}
+
+private extension UIColor {
+    static let shadowColor = UIColor.black.cgColor
+}
+
+private extension String {
+    static var accept: String { "acceptButtonTitle".localized }
+    static var reject: String { "rejectButtonTitle".localized }
+}

--- a/T-Trips/MVVM/Main/Notifications/NotificationsView.swift
+++ b/T-Trips/MVVM/Main/Notifications/NotificationsView.swift
@@ -5,6 +5,7 @@ final class NotificationsView: UIView {
     let tableView: UITableView = {
         let table = UITableView()
         table.register(CustomTableCell.self, forCellReuseIdentifier: CustomTableCell.reuseId)
+        table.register(InvitationCell.self, forCellReuseIdentifier: InvitationCell.reuseId)
         return table
     }()
 

--- a/T-Trips/MVVM/Main/Notifications/NotificationsViewController.swift
+++ b/T-Trips/MVVM/Main/Notifications/NotificationsViewController.swift
@@ -29,11 +29,26 @@ extension NotificationsViewController: UITableViewDataSource, UITableViewDelegat
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: CustomTableCell.reuseId, for: indexPath) as? CustomTableCell else {
-            return UITableViewCell()
+        let item = viewModel.notifications[indexPath.row]
+        if item.type == .invitation {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: InvitationCell.reuseId, for: indexPath) as? InvitationCell else {
+                return UITableViewCell()
+            }
+            cell.configure(message: item.message)
+            cell.onAccept = { [weak self] in
+                self?.viewModel.respond(to: item, accept: true) { tableView.reloadData() }
+            }
+            cell.onReject = { [weak self] in
+                self?.viewModel.respond(to: item, accept: false) { tableView.reloadData() }
+            }
+            return cell
+        } else {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: CustomTableCell.reuseId, for: indexPath) as? CustomTableCell else {
+                return UITableViewCell()
+            }
+            cell.configure(with: item.message)
+            return cell
         }
-        cell.configure(with: viewModel.notifications[indexPath.row].message)
-        return cell
     }
 
     func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
@@ -44,12 +59,14 @@ extension NotificationsViewController: UITableViewDataSource, UITableViewDelegat
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return .tvRowHeight
+        let item = viewModel.notifications[indexPath.row]
+        return item.type == .invitation ? .invitationRowHeight : .tvRowHeight
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let item = viewModel.notifications[indexPath.row]
+        guard item.type != .invitation else { return }
         let alert = UIAlertController(title: nil, message: item.message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         present(alert, animated: true)
@@ -58,4 +75,5 @@ extension NotificationsViewController: UITableViewDataSource, UITableViewDelegat
 
 private extension CGFloat {
     static let tvRowHeight: CGFloat = 100
+    static let invitationRowHeight: CGFloat = 160
 }

--- a/T-Trips/MVVM/Main/Notifications/NotificationsViewModel.swift
+++ b/T-Trips/MVVM/Main/Notifications/NotificationsViewModel.swift
@@ -14,4 +14,15 @@ final class NotificationsViewModel {
             }
         }
     }
+
+    func respond(to item: NotificationItem, accept: Bool, completion: @escaping () -> Void) {
+        MockAPIService.shared.respondToInvitation(notificationId: item.id, accept: accept) { [weak self] in
+            DispatchQueue.main.async {
+                if let index = self?.notifications.firstIndex(where: { $0.id == item.id }) {
+                    self?.notifications.remove(at: index)
+                }
+                completion()
+            }
+        }
+    }
 }

--- a/T-Trips/Utils/Mocks.swift
+++ b/T-Trips/Utils/Mocks.swift
@@ -19,9 +19,9 @@ enum MockData {
     ]
 
     static let trips: [Trip] = [
-        Trip(id: 1, adminId: users[0].id, title: "Отпуск в Сочи", startDate: Date(), endDate: Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date(), budget: 100000, description: "Море и пляж", status: .active, participantIds: [users[0].id, users[1].id, users[2].id]),
+        Trip(id: 1, adminId: users[0].id, title: "Отпуск в Сочи", startDate: Date(), endDate: Calendar.current.date(byAdding: .day, value: 7, to: Date()) ?? Date(), budget: 100000, description: "Море и пляж", status: .active, participantIds: [users[0].id, users[2].id]),
         Trip(id: 2, adminId: users[2].id, title: "Горное восхождение", startDate: Date().addingTimeInterval(-86400 * 10), endDate: Date().addingTimeInterval(-86400 * 3), budget: 75000, description: "Приключение в горах", status: .completed, participantIds: [users[2].id, users[3].id, users[4].id]),
-        Trip(id: 3, adminId: users[1].id, title: "Бизнес-поездка", startDate: Date().addingTimeInterval(-86400 * 30), endDate: Date().addingTimeInterval(-86400 * 25), budget: 200000, description: "Встречи с партнёрами", status: .planning, participantIds: [users[1].id, users[5].id])
+        Trip(id: 3, adminId: users[1].id, title: "Бизнес-поездка", startDate: Date().addingTimeInterval(-86400 * 30), endDate: Date().addingTimeInterval(-86400 * 25), budget: 200000, description: "Встречи с партнёрами", status: .planning, participantIds: [users[1].id])
     ]
 
     static let participants: [TripParticipant] = [
@@ -50,7 +50,7 @@ enum MockData {
     ]
 
     static let notifications: [NotificationItem] = [
-        NotificationItem(id: 1, userId: 1, tripId: trips[0].id, type: .invitation, message: "Вас добавили в поездку 'Отпуск в Сочи'", status: .unread, createdAt: Date()),
+        NotificationItem(id: 1, userId: 2, tripId: trips[0].id, type: .invitation, message: "Иван Иванов приглашает вас в событие Отпуск в Сочи", status: .unread, createdAt: Date()),
         NotificationItem(id: 2, userId: 2, tripId: trips[1].id, type: .expenseAdded, message: "Новый расход добавлен", status: .read, createdAt: Date().addingTimeInterval(-20000)),
         NotificationItem(id: 3, userId: 5, tripId: trips[2].id, type: .debtCreated, message: "У вас новый долг", status: .archived, createdAt: Date().addingTimeInterval(-40000))
     ]


### PR DESCRIPTION
## Summary
- handle invitation notifications with accept/reject actions
- add InvitationCell with accept/reject buttons
- send invitations when creating a trip
- update mock data and service models for invitations
- localize button titles

## Testing
- `swiftlint version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478af6fae8832c933bd547544a0391