### PR TITLE
Implement network API service

### DIFF
--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
@@ -59,7 +59,7 @@ final class AddExpenseViewModel {
             paidForUserIds: payeeIds
         )
 
-        MockAPIService.shared.createExpense(tripId: tripId, dto: dto, ownerId: payerId) { [weak self] expense in
+        NetworkAPIService.shared.createExpense(tripId: tripId, dto: dto, ownerId: payerId) { [weak self] expense in
             DispatchQueue.main.async {
                 self?.onAdd?(expense)
             }

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewModel.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewModel.swift
@@ -41,7 +41,7 @@ final class CreateTripViewModel {
             participantIds: participantIds
         )
 
-        MockAPIService.shared.createTrip(dto, adminId: adminId) { [weak self] trip in
+        NetworkAPIService.shared.createTrip(dto, adminId: adminId) { [weak self] trip in
             DispatchQueue.main.async {
                 self?.onTripCreated?(trip)
             }

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
@@ -25,7 +25,7 @@ final class DebtDetailViewModel {
         creditorPhone = creditor?.phone ?? ""
         tripTitle = trip?.title ?? ""
         amountText = debt.amount.rubleString
-        showsPayButton = canPay && (MockAPIService.shared.currentUser?.id == debt.fromUserId)
+        showsPayButton = canPay && (NetworkAPIService.shared.currentUser?.id == debt.fromUserId)
     }
 
     func payTapped() {

--- a/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -19,7 +19,7 @@ final class DebtsViewModel {
     }
 
     private func loadTripStatus() {
-        MockAPIService.shared.getTrip(id: tripId) { [weak self] trip in
+        NetworkAPIService.shared.getTrip(id: tripId) { [weak self] trip in
             DispatchQueue.main.async {
                 self?.tripStatus = trip?.status
                 self?.loadDebts()
@@ -28,7 +28,7 @@ final class DebtsViewModel {
     }
 
     func loadDebts() {
-        MockAPIService.shared.getDebts(tripId: tripId, userId: userId) { [weak self] debts in
+        NetworkAPIService.shared.getDebts(tripId: tripId, userId: userId) { [weak self] debts in
             DispatchQueue.main.async {
                 self?.debts = debts
             }
@@ -39,7 +39,7 @@ final class DebtsViewModel {
         guard isTripCompleted else { return }
         guard debts.indices.contains(index) else { return }
         let id = debts[index].debtId
-        MockAPIService.shared.deleteDebt(id: id) { [weak self] in
+        NetworkAPIService.shared.deleteDebt(id: id) { [weak self] in
             DispatchQueue.main.async {
                 self?.debts.remove(at: index)
             }

--- a/T-Trips/MVVM/Main/EditProfile/EditProfileViewController.swift
+++ b/T-Trips/MVVM/Main/EditProfile/EditProfileViewController.swift
@@ -7,7 +7,7 @@ final class EditProfileViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
 
     init() {
-        guard let user = MockAPIService.shared.currentUser else {
+        guard let user = NetworkAPIService.shared.currentUser else {
             fatalError("No logged user")
         }
         self.viewModel = EditProfileViewModel(user: user)
@@ -15,7 +15,7 @@ final class EditProfileViewController: UIViewController {
     }
 
     required init?(coder: NSCoder) {
-        guard let user = MockAPIService.shared.currentUser else { return nil }
+        guard let user = NetworkAPIService.shared.currentUser else { return nil }
         self.viewModel = EditProfileViewModel(user: user)
         super.init(coder: coder)
     }

--- a/T-Trips/MVVM/Main/EditProfile/EditProfileViewModel.swift
+++ b/T-Trips/MVVM/Main/EditProfile/EditProfileViewModel.swift
@@ -24,7 +24,7 @@ final class EditProfileViewModel {
     }
 
     func save() {
-        MockAPIService.shared.updateCurrentUser(firstName: firstName, lastName: lastName, phone: phone) { [weak self] user in
+        NetworkAPIService.shared.updateCurrentUser(firstName: firstName, lastName: lastName, phone: phone) { [weak self] user in
             DispatchQueue.main.async {
                 if user != nil { self?.onSaved?() }
             }

--- a/T-Trips/MVVM/Main/Notifications/NotificationsViewModel.swift
+++ b/T-Trips/MVVM/Main/Notifications/NotificationsViewModel.swift
@@ -8,7 +8,7 @@ final class NotificationsViewModel {
     }
 
     private func load() {
-        MockAPIService.shared.getNotifications { [weak self] items in
+        NetworkAPIService.shared.getNotifications { [weak self] items in
             DispatchQueue.main.async {
                 self?.notifications = items
             }
@@ -16,7 +16,7 @@ final class NotificationsViewModel {
     }
 
     func respond(to item: NotificationItem, accept: Bool, completion: @escaping () -> Void) {
-        MockAPIService.shared.respondToInvitation(notificationId: item.id, accept: accept) { [weak self] in
+        NetworkAPIService.shared.respondToInvitation(notificationId: item.id, accept: accept) { [weak self] in
             DispatchQueue.main.async {
                 if let index = self?.notifications.firstIndex(where: { $0.id == item.id }) {
                     self?.notifications.remove(at: index)

--- a/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
+++ b/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
@@ -101,7 +101,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
         alert.addAction(UIAlertAction(title: String.cancelTitle, style: .cancel))
         alert.addAction(
             UIAlertAction(title: String.confirmButtonTitle, style: .destructive) { _ in
-                MockAPIService.shared.logout()
+                NetworkAPIService.shared.logout()
                 guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                       let delegate = scene.delegate as? SceneDelegate,
                       let window = delegate.window else { return }

--- a/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -105,7 +105,7 @@ final class TripViewController: UIViewController {
     }
 
     private func showDebts() {
-        let uid = MockAPIService.shared.currentUser?.id
+        let uid = NetworkAPIService.shared.currentUser?.id
         let vc = DebtsViewController(tripId: viewModel.trip.id, userId: uid)
         vc.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(vc, animated: true)

--- a/T-Trips/MVVM/Main/Trip/TripViewModel.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewModel.swift
@@ -14,7 +14,7 @@ final class TripViewModel {
     let trip: Trip
 
     var isAdmin: Bool {
-        MockAPIService.shared.currentUser?.id == trip.adminId
+        NetworkAPIService.shared.currentUser?.id == trip.adminId
     }
 
     // MARK: - Handlers
@@ -28,7 +28,7 @@ final class TripViewModel {
 
     // MARK: - Data Loading
     private func loadExpenses() {
-        MockAPIService.shared.getExpenses(tripId: trip.id) { [weak self] expenses in
+        NetworkAPIService.shared.getExpenses(tripId: trip.id) { [weak self] expenses in
             DispatchQueue.main.async {
                 self?.expenses = expenses
             }
@@ -47,7 +47,7 @@ final class TripViewModel {
     func deleteExpense(at index: Int) {
         guard isAdmin else { return }
         guard expenses.indices.contains(index), let id = expenses[index].id else { return }
-        MockAPIService.shared.deleteExpense(id: id) { [weak self] in
+        NetworkAPIService.shared.deleteExpense(id: id) { [weak self] in
             DispatchQueue.main.async {
                 self?.expenses.remove(at: index)
             }
@@ -55,8 +55,8 @@ final class TripViewModel {
     }
 
     func leaveTrip(completion: @escaping () -> Void) {
-        guard let userId = MockAPIService.shared.currentUser?.id else { return }
-        MockAPIService.shared.leaveTrip(tripId: trip.id, userId: userId) { _ in
+        guard let userId = NetworkAPIService.shared.currentUser?.id else { return }
+        NetworkAPIService.shared.leaveTrip(tripId: trip.id, userId: userId) { _ in
             DispatchQueue.main.async { completion() }
         }
     }

--- a/T-Trips/MVVM/Main/Trips/TripsViewController.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewController.swift
@@ -54,7 +54,7 @@ final class TripsViewController: UIViewController {
 
         viewModel.onAddTrip = { [weak self] in
             guard let self = self else { return }
-            let adminId = MockAPIService.shared.currentUser?.id ?? 0
+            let adminId = NetworkAPIService.shared.currentUser?.id ?? 0
             let createVC = CreateTripViewController(adminId: adminId)
             createVC.onTripCreated = { [weak self] trip in
                 self?.viewModel.addTrip(trip)

--- a/T-Trips/MVVM/Main/Trips/TripsViewModel.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewModel.swift
@@ -50,7 +50,7 @@ final class TripsViewModel {
             .store(in: &cancellables)
     }
     func loadTrips(for filter: Filter) {
-        MockAPIService.shared.getUserTrips(status: filter.correspondingStatus) { [weak self] trips in
+        NetworkAPIService.shared.getUserTrips(status: filter.correspondingStatus) { [weak self] trips in
             DispatchQueue.main.async {
                 self?.trips = trips
             }

--- a/T-Trips/Models/APIModels.swift
+++ b/T-Trips/Models/APIModels.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct TripDtoForCreate: Codable {
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let status: Trip.Status
+    let budget: Double
+    let description: String?
+    let participantIds: [Int64]
+}
+
+struct ExpenseDtoForCreate: Codable {
+    let category: Expense.Category
+    let amount: Double
+    let title: String
+    let paidForUserIds: [Int64]
+}

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -309,24 +309,6 @@ private extension MockAPIService {
     }
 }
 
-// MARK: - DTOs
-struct TripDtoForCreate {
-    let title: String
-    let startDate: Date
-    let endDate: Date
-    let status: Trip.Status
-    let budget: Double
-    let description: String?
-    let participantIds: [Int64]
-}
-
-struct ExpenseDtoForCreate {
-    let category: Expense.Category
-    let amount: Double
-    let title: String
-    let paidForUserIds: [Int64]
-}
-
 // MARK: - User management
 extension MockAPIService {
     func updateCurrentUser(firstName: String, lastName: String, phone: String, completion: @escaping (User?) -> Void) {

--- a/T-Trips/Utils/NetworkAPIService.swift
+++ b/T-Trips/Utils/NetworkAPIService.swift
@@ -8,6 +8,7 @@ final class NetworkAPIService {
     /// Base URL for the backend API.
     private let baseURL = URL(string: "http://82.202.136.132:8082")!
     private let session: URLSession
+    private(set) var currentUser: User?
 
     init(session: URLSession = .shared) {
         self.session = session
@@ -60,5 +61,324 @@ final class NetworkAPIService {
         task.resume()
     }
 
-    // MARK: - TODO: Implement other methods using real API
+    // MARK: - Trips
+    func getUserTrips(status: Trip.Status, completion: @escaping ([Trip]) -> Void) {
+        var components = URLComponents(url: baseURL.appendingPathComponent("/trips"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "status", value: status.rawValue)]
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let trips = try? JSONDecoder.apiDecoder.decode([Trip].self, from: data)
+            else {
+                completion([])
+                return
+            }
+            completion(trips)
+        }
+        task.resume()
+    }
+
+    func getTrip(id: Int64, completion: @escaping (Trip?) -> Void) {
+        let url = baseURL.appendingPathComponent("/trips/\(id)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let trip = try? JSONDecoder.apiDecoder.decode(Trip.self, from: data)
+            else {
+                completion(nil)
+                return
+            }
+            completion(trip)
+        }
+        task.resume()
+    }
+
+    func createTrip(_ dto: TripDtoForCreate, adminId: Int64, completion: @escaping (Trip?) -> Void) {
+        let url = baseURL.appendingPathComponent("/trips")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let payload: [String: Any] = [
+            "title": dto.title,
+            "startDate": ISO8601DateFormatter().string(from: dto.startDate),
+            "endDate": ISO8601DateFormatter().string(from: dto.endDate),
+            "status": dto.status.rawValue,
+            "budget": dto.budget,
+            "description": dto.description as Any,
+            "participantIds": dto.participantIds,
+            "adminId": adminId
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let trip = try? JSONDecoder.apiDecoder.decode(Trip.self, from: data)
+            else {
+                completion(nil)
+                return
+            }
+            completion(trip)
+        }
+        task.resume()
+    }
+
+    func updateTrip(_ trip: Trip, completion: @escaping (Trip?) -> Void) {
+        let url = baseURL.appendingPathComponent("/trips/\(trip.id)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(trip)
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let updated = try? JSONDecoder.apiDecoder.decode(Trip.self, from: data)
+            else {
+                completion(nil)
+                return
+            }
+            completion(updated)
+        }
+        task.resume()
+    }
+
+    func leaveTrip(tripId: Int64, userId: Int64, completion: @escaping (Trip?) -> Void) {
+        let url = baseURL.appendingPathComponent("/trips/\(tripId)/leave")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(["userId": userId])
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode)
+            else {
+                completion(nil)
+                return
+            }
+            let trip = try? JSONDecoder.apiDecoder.decode(Trip.self, from: data)
+            completion(trip)
+        }
+        task.resume()
+    }
+
+    // MARK: - Expenses
+    func getExpenses(tripId: Int64, completion: @escaping ([Expense]) -> Void) {
+        let url = baseURL.appendingPathComponent("/trips/\(tripId)/expenses")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let expenses = try? JSONDecoder.apiDecoder.decode([Expense].self, from: data)
+            else {
+                completion([])
+                return
+            }
+            completion(expenses)
+        }
+        task.resume()
+    }
+
+    func createExpense(tripId: Int64, dto: ExpenseDtoForCreate, ownerId: Int64, completion: @escaping (Expense?) -> Void) {
+        let url = baseURL.appendingPathComponent("/trips/\(tripId)/expenses")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        request.httpBody = try? JSONEncoder().encode(dto)
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let expense = try? JSONDecoder.apiDecoder.decode(Expense.self, from: data)
+            else {
+                completion(nil)
+                return
+            }
+            completion(expense)
+        }
+        task.resume()
+    }
+
+    func deleteExpense(id: Int64, completion: @escaping () -> Void) {
+        let url = baseURL.appendingPathComponent("/expenses/\(id)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+
+        let task = session.dataTask(with: request) { _, response, _ in
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                completion()
+                return
+            }
+            completion()
+        }
+        task.resume()
+    }
+
+    // MARK: - Debts
+    func getDebts(tripId: Int64, userId: Int64?, completion: @escaping ([Debt]) -> Void) {
+        var components = URLComponents(url: baseURL.appendingPathComponent("/trips/\(tripId)/debts"), resolvingAgainstBaseURL: false)!
+        if let uid = userId {
+            components.queryItems = [URLQueryItem(name: "userId", value: String(uid))]
+        }
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let debts = try? JSONDecoder.apiDecoder.decode([Debt].self, from: data)
+            else {
+                completion([])
+                return
+            }
+            completion(debts)
+        }
+        task.resume()
+    }
+
+    func deleteDebt(id: String, completion: @escaping () -> Void) {
+        let url = baseURL.appendingPathComponent("/debts/\(id)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+
+        let task = session.dataTask(with: request) { _, response, _ in
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                completion()
+                return
+            }
+            completion()
+        }
+        task.resume()
+    }
+
+    // MARK: - Participants
+    func findParticipant(phone: String, completion: @escaping (User?) -> Void) {
+        var components = URLComponents(url: baseURL.appendingPathComponent("/participants/find"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "phone", value: phone)]
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode)
+            else {
+                completion(nil)
+                return
+            }
+            let user = try? JSONDecoder.apiDecoder.decode(User.self, from: data)
+            completion(user)
+        }
+        task.resume()
+    }
+
+    // MARK: - User management
+    func updateCurrentUser(firstName: String, lastName: String, phone: String, completion: @escaping (User?) -> Void) {
+        let url = baseURL.appendingPathComponent("/user")
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: String] = [
+            "firstName": firstName,
+            "lastName": lastName,
+            "phone": phone
+        ]
+        request.httpBody = try? JSONEncoder().encode(body)
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode)
+            else {
+                completion(nil)
+                return
+            }
+            let user = try? JSONDecoder.apiDecoder.decode(User.self, from: data)
+            completion(user)
+        }
+        task.resume()
+    }
+
+    func getNotifications(completion: @escaping ([NotificationItem]) -> Void) {
+        let url = baseURL.appendingPathComponent("/notifications")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let task = session.dataTask(with: request) { data, response, _ in
+            guard
+                let data = data,
+                let httpResponse = response as? HTTPURLResponse,
+                (200..<300).contains(httpResponse.statusCode),
+                let notes = try? JSONDecoder.apiDecoder.decode([NotificationItem].self, from: data)
+            else {
+                completion([])
+                return
+            }
+            completion(notes)
+        }
+        task.resume()
+    }
+
+    func respondToInvitation(notificationId: Int, accept: Bool, completion: @escaping () -> Void) {
+        let url = baseURL.appendingPathComponent("/notifications/\(notificationId)/respond")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(["accept": accept])
+
+        let task = session.dataTask(with: request) { _, response, _ in
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                completion()
+                return
+            }
+            completion()
+        }
+        task.resume()
+    }
+
+    func logout() {
+        let url = baseURL.appendingPathComponent("/auth/logout")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        let task = session.dataTask(with: request) { _, _, _ in }
+        task.resume()
+    }
 }


### PR DESCRIPTION
## Summary
- move DTO types to a shared file
- expand `NetworkAPIService` with real HTTP calls for trips, expenses, debts and notifications
- store `currentUser` inside the network service
- switch all ViewModels and controllers from mock service to the network one

## Testing
- `swiftlint` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68479a291424832c906c366a631c4988