### PR TITLE
Fix AddExpense ViewModel optional expense handling

### DIFF
--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewModel.swift
@@ -61,6 +61,7 @@ final class AddExpenseViewModel {
 
         NetworkAPIService.shared.createExpense(tripId: tripId, dto: dto, ownerId: payerId) { [weak self] expense in
             DispatchQueue.main.async {
+                guard let expense = expense else { return }
                 self?.onAdd?(expense)
             }
         }


### PR DESCRIPTION
## Summary
- fix optional unwrap when passing created expense to onAdd handler

## Testing
- `xcodebuild -list -project T-Trips/T-Trips.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479c6e5c98832ca4368409174a9821