### PR TITLE
Improve registration error handling

### DIFF
--- a/T-Trips/Localization/en.lproj/Localizable.strings
+++ b/T-Trips/Localization/en.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "passwordMismatch" = "Passwords do not match";
 "phoneIncomplete" = "Phone number is incomplete";
 "phoneExists" = "User with this phone already exists";
+"registrationFailed" = "Registration failed. Please try again";
 "firstName" = "First Name";
 "lastName" = "Last Name";
 "payButtonTitle" = "Pay";

--- a/T-Trips/Localization/ru.lproj/Localizable.strings
+++ b/T-Trips/Localization/ru.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "passwordMismatch" = "Пароли не совпадают";
 "phoneIncomplete" = "Номер телефона заполнен не полностью";
 "phoneExists" = "Пользователь с таким номером уже существует";
+"registrationFailed" = "Не удалось зарегистрироваться. Попробуйте снова";
 "firstName" = "Имя";
 "lastName" = "Фамилия";
 "payButtonTitle" = "Оплатить";

--- a/T-Trips/MVVM/Register/RegisterViewModel.swift
+++ b/T-Trips/MVVM/Register/RegisterViewModel.swift
@@ -70,12 +70,15 @@ final class RegisterViewModel {
             firstName: first,
             lastName: last,
             password: password
-        ) { [weak self] success in
+        ) { [weak self] result in
             DispatchQueue.main.async {
-                if success {
+                switch result {
+                case .success:
                     self?.onRegisterSuccess?()
-                } else {
+                case .failure(.phoneExists):
                     self?.onRegisterFailure?(String.phoneExists)
+                case .failure:
+                    self?.onRegisterFailure?(String.registrationFailed)
                 }
             }
         }
@@ -97,4 +100,5 @@ private extension String {
     static var passwordMismatch: String { "passwordMismatch".localized }
     static var phoneIncomplete: String { "phoneIncomplete".localized }
     static var phoneExists: String { "phoneExists".localized }
+    static var registrationFailed: String { "registrationFailed".localized }
 }

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -247,10 +247,10 @@ final class MockAPIService {
         }
     }
 
-    func register(phone: String, firstName: String, lastName: String, password: String, completion: @escaping (Bool) -> Void) {
+    func register(phone: String, firstName: String, lastName: String, password: String, completion: @escaping (Result<Void, NetworkAPIService.RegisterError>) -> Void) {
         asyncDelay {
             guard self.users.first(where: { $0.phone == phone }) == nil else {
-                completion(false)
+                completion(.failure(.phoneExists))
                 return
             }
             let newId = (self.users.map { $0.id }.max() ?? 0) + 1
@@ -266,7 +266,7 @@ final class MockAPIService {
             )
             self.users.append(user)
             self.currentUserId = user.id
-            completion(true)
+            completion(.success(()))
         }
     }
 }


### PR DESCRIPTION
## Summary
- report a registration failure separately from phone-exists error
- localize a new generic error string

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a038017c832c939eb0dda92ffa72