### PR TITLE
Update Network API paths

### DIFF
--- a/T-Trips/MVVM/Main/Trip/TripViewModel.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewModel.swift
@@ -47,7 +47,7 @@ final class TripViewModel {
     func deleteExpense(at index: Int) {
         guard isAdmin else { return }
         guard expenses.indices.contains(index), let id = expenses[index].id else { return }
-        NetworkAPIService.shared.deleteExpense(id: id) { [weak self] in
+        NetworkAPIService.shared.deleteExpense(tripId: trip.id, id: id) { [weak self] in
             DispatchQueue.main.async {
                 self?.expenses.remove(at: index)
             }

--- a/T-Trips/MVVM/Register/RegisterViewModel.swift
+++ b/T-Trips/MVVM/Register/RegisterViewModel.swift
@@ -66,9 +66,10 @@ final class RegisterViewModel {
         let phoneNormalized = "+" + digits
 
         NetworkAPIService.shared.register(
+            login: phoneNormalized,
             phone: phoneNormalized,
-            firstName: first,
-            lastName: last,
+            name: first,
+            surname: last,
             password: password
         ) { [weak self] result in
             DispatchQueue.main.async {

--- a/T-Trips/Models/APIModels.swift
+++ b/T-Trips/Models/APIModels.swift
@@ -25,9 +25,10 @@ struct LoginRequest: Codable {
 
 /// Request payload for the register endpoint.
 struct RegisterRequest: Codable {
+    let login: String
     let phone: String
-    let firstName: String
-    let lastName: String
     let password: String
+    let name: String
+    let surname: String
 }
 

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -156,9 +156,9 @@ final class MockAPIService {
         }
     }
 
-    func deleteExpense(id: Int64, completion: @escaping () -> Void) {
+    func deleteExpense(tripId: Int64, id: Int64, completion: @escaping () -> Void) {
         asyncDelay {
-            self.expenses.removeAll { $0.id == id }
+            self.expenses.removeAll { $0.id == id && $0.tripId == tripId }
             completion()
         }
     }
@@ -247,7 +247,7 @@ final class MockAPIService {
         }
     }
 
-    func register(phone: String, firstName: String, lastName: String, password: String, completion: @escaping (Result<Void, NetworkAPIService.RegisterError>) -> Void) {
+    func register(login: String, phone: String, name: String, surname: String, password: String, completion: @escaping (Result<Void, NetworkAPIService.RegisterError>) -> Void) {
         asyncDelay {
             guard self.users.first(where: { $0.phone == phone }) == nil else {
                 completion(.failure(.phoneExists))
@@ -257,8 +257,8 @@ final class MockAPIService {
             let user = User(
                 id: newId,
                 phone: phone,
-                firstName: firstName,
-                lastName: lastName,
+                firstName: name,
+                lastName: surname,
                 hashPassword: password,
                 status: .active,
                 role: .user,


### PR DESCRIPTION
## Summary
- update register API payload
- switch networking to `/api/v1` routes
- patch UpdateUser, Debts and Expenses endpoints

## Testing
- `swiftc -parse T-Trips/Models/APIModels.swift T-Trips/Utils/NetworkAPIService.swift T-Trips/Utils/MockAPIService.swift T-Trips/MVVM/Register/RegisterViewModel.swift T-Trips/MVVM/Main/Trip/TripViewModel.swift`

------
https://chatgpt.com/codex/tasks/task_e_6847ac105400832c9b7ea169a151a523