### PR TITLE
Align project with new API spec

### DIFF
--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -18,8 +18,8 @@ final class CreateTripViewController: UIViewController {
         }
     }
 
-    init(adminId: Int64 = 0) {
-        self.viewModel = CreateTripViewModel(adminId: adminId)
+    init() {
+        self.viewModel = CreateTripViewModel()
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewModel.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewModel.swift
@@ -3,7 +3,6 @@ import Combine
 
 final class CreateTripViewModel {
     var onTripCreated: ((Trip) -> Void)?
-    private let adminId: Int64
     @Published var title: String = ""
     @Published var budget: String = ""
     @Published var description: String = ""
@@ -15,8 +14,7 @@ final class CreateTripViewModel {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(adminId: Int64 = 0) {
-        self.adminId = adminId
+    init() {
         Publishers.CombineLatest4($title, $budget, $description, $participantIds)
             .combineLatest(Publishers.CombineLatest($startDate, $endDate))
             .map { combined, dates in
@@ -41,7 +39,7 @@ final class CreateTripViewModel {
             participantIds: participantIds
         )
 
-        NetworkAPIService.shared.createTrip(dto, adminId: adminId) { [weak self] trip in
+        NetworkAPIService.shared.createTrip(dto) { [weak self] trip in
             DispatchQueue.main.async {
                 guard let trip = trip else { return }
                 self?.onTripCreated?(trip)

--- a/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -39,7 +39,7 @@ final class DebtsViewModel {
         guard isTripCompleted else { return }
         guard debts.indices.contains(index) else { return }
         let id = debts[index].debtId
-        NetworkAPIService.shared.deleteDebt(id: id) { [weak self] in
+        NetworkAPIService.shared.payDebt(id: id) { [weak self] in
             DispatchQueue.main.async {
                 self?.debts.remove(at: index)
             }

--- a/T-Trips/MVVM/Main/Trips/TripsViewController.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewController.swift
@@ -54,8 +54,7 @@ final class TripsViewController: UIViewController {
 
         viewModel.onAddTrip = { [weak self] in
             guard let self = self else { return }
-            let adminId = NetworkAPIService.shared.currentUser?.id ?? 0
-            let createVC = CreateTripViewController(adminId: adminId)
+            let createVC = CreateTripViewController()
             createVC.onTripCreated = { [weak self] trip in
                 self?.viewModel.addTrip(trip)
             }

--- a/T-Trips/Models/APIModels.swift
+++ b/T-Trips/Models/APIModels.swift
@@ -32,3 +32,14 @@ struct RegisterRequest: Codable {
     let surname: String
 }
 
+/// Response with JWT access and refresh tokens.
+struct JwtTokenPair: Codable {
+    let accessToken: String
+    let refreshToken: String
+}
+
+/// Request payload for token refresh endpoint.
+struct RefreshTokenRequest: Codable {
+    let refreshToken: String
+}
+

--- a/T-Trips/Models/Debt.swift
+++ b/T-Trips/Models/Debt.swift
@@ -13,8 +13,14 @@ struct Debt: Codable, Identifiable {
     let fromUserId: Int64
     let toUserId: Int64
     let amount: Double
-    
+    var debtStatus: Status
+
     var id: String { debtId }
+
+    enum Status: String, Codable, CaseIterable {
+        case pending = "PENDING"
+        case payed = "PAYED"
+    }
 
     private enum CodingKeys: String, CodingKey {
         case debtId
@@ -22,5 +28,6 @@ struct Debt: Codable, Identifiable {
         case fromUserId
         case toUserId
         case amount
+        case debtStatus
     }
 }

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -48,9 +48,10 @@ final class MockAPIService {
         }
     }
 
-    func createTrip(_ dto: TripDtoForCreate, adminId: Int64, completion: @escaping (Trip) -> Void) {
+    func createTrip(_ dto: TripDtoForCreate, completion: @escaping (Trip) -> Void) {
         asyncDelay {
             let newId = (self.trips.map { $0.id }.max() ?? 0) + 1
+            let adminId = dto.participantIds.first ?? 0
             let trip = Trip(
                 id: newId,
                 adminId: adminId,
@@ -130,7 +131,8 @@ final class MockAPIService {
                         tripId: tripId,
                         fromUserId: uid,
                         toUserId: ownerId,
-                        amount: partAmount
+                        amount: partAmount,
+                        debtStatus: .pending
                     )
                     self.debts.append(debt)
                     self.addNotification(
@@ -174,9 +176,11 @@ final class MockAPIService {
         }
     }
 
-    func deleteDebt(id: String, completion: @escaping () -> Void) {
+    func payDebt(id: String, completion: @escaping () -> Void) {
         asyncDelay {
-            self.debts.removeAll { $0.debtId == id }
+            if let index = self.debts.firstIndex(where: { $0.debtId == id }) {
+                self.debts[index].debtStatus = .payed
+            }
             completion()
         }
     }

--- a/T-Trips/Utils/Mocks.swift
+++ b/T-Trips/Utils/Mocks.swift
@@ -44,9 +44,9 @@ enum MockData {
     ]
 
     static let debts: [Debt] = [
-        Debt(debtId: "1", tripId: trips[0].id, fromUserId: users[1].id, toUserId: users[0].id, amount: 1250.37),
-        Debt(debtId: "2", tripId: trips[0].id, fromUserId: users[2].id, toUserId: users[0].id, amount: 500),
-        Debt(debtId: "3", tripId: trips[1].id, fromUserId: users[3].id, toUserId: users[2].id, amount: 300)
+        Debt(debtId: "1", tripId: trips[0].id, fromUserId: users[1].id, toUserId: users[0].id, amount: 1250.37, debtStatus: .pending),
+        Debt(debtId: "2", tripId: trips[0].id, fromUserId: users[2].id, toUserId: users[0].id, amount: 500, debtStatus: .pending),
+        Debt(debtId: "3", tripId: trips[1].id, fromUserId: users[3].id, toUserId: users[2].id, amount: 300, debtStatus: .pending)
     ]
 
     static let notifications: [NotificationItem] = [

--- a/T-Trips/Utils/NetworkAPIService.swift
+++ b/T-Trips/Utils/NetworkAPIService.swift
@@ -10,6 +10,7 @@ final class NetworkAPIService {
     private let baseURL = URL(string: "http://82.202.136.132:8082")!
     private let session: URLSession
     private(set) var currentUser: User?
+    private(set) var tokenPair: JwtTokenPair?
 
     init(session: URLSession = .shared) {
         self.session = session
@@ -46,10 +47,9 @@ final class NetworkAPIService {
                 completion(false)
                 return
             }
-
             if let data = data,
-               let user = try? JSONDecoder.apiDecoder.decode(User.self, from: data) {
-                self.currentUser = user
+               let pair = try? JSONDecoder.apiDecoder.decode(JwtTokenPair.self, from: data) {
+                self.tokenPair = pair
             } else {
                 self.logError(request: request, response: response, data: data, error: error)
             }
@@ -140,7 +140,7 @@ final class NetworkAPIService {
         task.resume()
     }
 
-    func createTrip(_ dto: TripDtoForCreate, adminId: Int64, completion: @escaping (Trip?) -> Void) {
+    func createTrip(_ dto: TripDtoForCreate, completion: @escaping (Trip?) -> Void) {
         let url = baseURL.appendingPathComponent("/api/v1/trips")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -152,8 +152,7 @@ final class NetworkAPIService {
             "status": dto.status.rawValue,
             "budget": dto.budget,
             "description": dto.description as Any,
-            "participantIds": dto.participantIds,
-            "adminId": adminId
+            "participantIds": dto.participantIds
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
 
@@ -311,7 +310,7 @@ final class NetworkAPIService {
         task.resume()
     }
 
-    func deleteDebt(id: String, completion: @escaping () -> Void) {
+    func payDebt(id: String, completion: @escaping () -> Void) {
         let url = baseURL.appendingPathComponent("/api/v1/debts/\(id)")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"


### PR DESCRIPTION
## Summary
- add JWT token models
- add debt status field
- support token login
- adjust create trip call signature
- rename deleteDebt to payDebt
- adapt view models and mock data to new API

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6847b25c7b30832cbc258c7c4c371a8f