### PR TITLE
Fix login request field name

### DIFF
--- a/T-Trips/MVVM/Auth/AuthViewModel.swift
+++ b/T-Trips/MVVM/Auth/AuthViewModel.swift
@@ -40,7 +40,7 @@ final class AuthViewModel {
         // Normalize phone number to remove formatting
         let digits = phone.filter { $0.isNumber }
         let normalized = "+" + digits
-        NetworkAPIService.shared.authenticate(phone: normalized, password: password) { [weak self] success in
+        NetworkAPIService.shared.authenticate(login: normalized, password: password) { [weak self] success in
             DispatchQueue.main.async {
                 if success {
                     self?.onLoginSuccess?()

--- a/T-Trips/Models/APIModels.swift
+++ b/T-Trips/Models/APIModels.swift
@@ -19,7 +19,8 @@ struct ExpenseDtoForCreate: Codable {
 
 /// Request payload for the login endpoint.
 struct LoginRequest: Codable {
-    let phone: String
+    /// Login or phone number used for authentication
+    let login: String
     let password: String
 }
 

--- a/T-Trips/Utils/MockAPIService.swift
+++ b/T-Trips/Utils/MockAPIService.swift
@@ -243,9 +243,9 @@ final class MockAPIService {
     }
 
     // MARK: - Auth
-    func authenticate(phone: String, password: String, completion: @escaping (Bool) -> Void) {
+    func authenticate(login: String, password: String, completion: @escaping (Bool) -> Void) {
         asyncDelay {
-            let user = self.users.first { $0.phone == phone && $0.hashPassword == password }
+            let user = self.users.first { $0.phone == login && $0.hashPassword == password }
             self.currentUserId = user?.id
             completion(user != nil)
         }

--- a/T-Trips/Utils/NetworkAPIService.swift
+++ b/T-Trips/Utils/NetworkAPIService.swift
@@ -30,12 +30,12 @@ final class NetworkAPIService {
     }
 
     // MARK: - Auth
-    func authenticate(phone: String, password: String, completion: @escaping (Bool) -> Void) {
+    func authenticate(login: String, password: String, completion: @escaping (Bool) -> Void) {
         let url = baseURL.appendingPathComponent("/api/v1/auth/login")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        let body = LoginRequest(phone: phone, password: password)
+        let body = LoginRequest(login: login, password: password)
         request.httpBody = try? JSONEncoder().encode(body)
 
         let task = session.dataTask(with: request) { data, response, error in


### PR DESCRIPTION
## Summary
- align login request with new API by sending `login` field
- update models and mock service accordingly

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b4de6f2c832cb705faa850d1c6dd