### PR TITLE
Switch to backend users and allow long trip titles

### DIFF
--- a/T-Trips/CustomViews/CustomTextField/CustomTextFieldDelegate.swift
+++ b/T-Trips/CustomViews/CustomTextField/CustomTextFieldDelegate.swift
@@ -35,15 +35,23 @@ final class CustomTextFieldDelegate: NSObject, UITextFieldDelegate {
             /// only letters and space are allowed
             let allowed = CharacterSet.letters.union(.whitespaces)
             guard string.rangeOfCharacter(from: allowed.inverted) == nil else { return false }
-            
+
             let prospective = (currentText as NSString).replacingCharacters(in: range, with: string)
             /// only one space in a row allowed
             if prospective.contains("  ") { return false }
-            /// not more than two words is allowd
+
+            /// not more than two words is allowed for name
             let words = prospective
                 .split(separator: " ", omittingEmptySubsequences: true)
             if words.count > 2 { return false }
-            
+
+            return true
+
+        case .title:
+            let allowed = CharacterSet.letters.union(.whitespaces)
+            guard string.rangeOfCharacter(from: allowed.inverted) == nil else { return false }
+            let prospective = (currentText as NSString).replacingCharacters(in: range, with: string)
+            if prospective.contains("  ") { return false }
             return true
             
         case .phoneNumber:
@@ -102,6 +110,12 @@ final class CustomTextFieldDelegate: NSObject, UITextFieldDelegate {
             textField.text = [first, last]
                 .filter { !$0.isEmpty }
                 .joined(separator: " ")
+
+        case .title:
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let capitalized = trimmed.capitalized
+            let singleSpaced = capitalized.replacingOccurrences(of: "  ", with: " ")
+            textField.text = singleSpaced
 
         case .phoneNumber:
             /// applies formatting after leaving the TF

--- a/T-Trips/CustomViews/CustomTextField/TextFieldFactory.swift
+++ b/T-Trips/CustomViews/CustomTextField/TextFieldFactory.swift
@@ -20,6 +20,8 @@ final class TextFieldFactory: TextFieldFactoryProtocol {
         switch model.state {
         case .name:
             textField.keyboardType = .default
+        case .title:
+            textField.keyboardType = .default
         case .phoneNumber:
             textField.keyboardType = .numberPad
        case .password:

--- a/T-Trips/CustomViews/CustomTextField/TextFieldModel.swift
+++ b/T-Trips/CustomViews/CustomTextField/TextFieldModel.swift
@@ -13,6 +13,7 @@ struct TextFieldModel {
 
     enum State {
         case name
+        case title
         case phoneNumber
         case password
         case money

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
@@ -53,7 +53,7 @@ final class CreateTripView: UIView {
     }()
 
     public private(set) lazy var titleTextField: CustomTextField = {
-        let model = TextFieldModel(placeholder: String.titlePlaceholder, state: .name)
+        let model = TextFieldModel(placeholder: String.titlePlaceholder, state: .title)
         let tf = textFieldFactory.makeTextField(with: model)
         tf.inputAccessoryView = accessoryToolbar
         return tf

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -8,7 +8,7 @@ final class CreateTripViewController: UIViewController {
     private let viewModel: CreateTripViewModel
     private var cancellables = Set<AnyCancellable>()
 
-    private let participants = MockData.users
+    private var participants: [User] = []
     private var selectedUsers: [User] = []
     private var filteredParticipants: [User] = []
     private let participantsPlaceholder = "Участники"
@@ -35,10 +35,17 @@ final class CreateTripViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = nil
+        loadParticipants()
         setupBindings()
         setupPickers()
         setupSuggestions()
         setupActions()
+    }
+
+    private func loadParticipants() {
+        NetworkAPIService.shared.getAllUsers { [weak self] users in
+            DispatchQueue.main.async { self?.participants = users }
+        }
     }
 
     private func setupBindings() {

--- a/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
+++ b/T-Trips/MVVM/Main/DebtDetail/DebtDetailViewModel.swift
@@ -15,15 +15,14 @@ final class DebtDetailViewModel {
 
     var onPay: (() -> Void)?
 
-    init(debt: Debt, canPay: Bool) {
-        let creditor = MockData.users.first { $0.id == debt.toUserId }
-        let trip = MockData.trips.first { $0.id == debt.tripId }
+    init(debt: Debt, users: [User], tripTitle: String, canPay: Bool) {
+        let creditor = users.first { $0.id == debt.toUserId }
 
         creditorName = [creditor?.firstName, creditor?.lastName]
             .compactMap { $0 }
             .joined(separator: " ")
         creditorPhone = creditor?.phone ?? ""
-        tripTitle = trip?.title ?? ""
+        self.tripTitle = tripTitle
         amountText = debt.amount.rubleString
         showsPayButton = canPay && (NetworkAPIService.shared.currentUser?.id == debt.fromUserId)
     }

--- a/T-Trips/MVVM/Main/Debts/DebtCell.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtCell.swift
@@ -52,9 +52,9 @@ final class DebtCell: UITableViewCell {
                                         cornerRadius: contentView.layer.cornerRadius).cgPath
     }
 
-    func configure(with debt: Debt) {
-        let fromUser = MockData.users.first { $0.id == debt.fromUserId }
-        let toUser = MockData.users.first { $0.id == debt.toUserId }
+    func configure(with debt: Debt, users: [User]) {
+        let fromUser = users.first { $0.id == debt.fromUserId }
+        let toUser = users.first { $0.id == debt.toUserId }
         let fromName = [fromUser?.firstName, fromUser?.lastName].compactMap { $0 }.joined(separator: " ")
         let toName = [toUser?.firstName, toUser?.lastName].compactMap { $0 }.joined(separator: " ")
         participantsLabel.text = "\(fromName) → \(toName)"

--- a/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -9,6 +9,7 @@ final class DebtsViewModel {
     private let userId: Int64?
 
     private var tripStatus: Trip.Status?
+    private(set) var tripTitle: String = ""
 
     var isTripCompleted: Bool { tripStatus == .completed }
 
@@ -22,6 +23,7 @@ final class DebtsViewModel {
         NetworkAPIService.shared.getTrip(id: tripId) { [weak self] trip in
             DispatchQueue.main.async {
                 self?.tripStatus = trip?.status
+                self?.tripTitle = trip?.title ?? ""
                 self?.loadDebts()
             }
         }

--- a/T-Trips/Models/Expense.swift
+++ b/T-Trips/Models/Expense.swift
@@ -17,8 +17,13 @@ struct Expense: Codable, Identifiable {
     let createdAt: Date?
     let paidForUserIds: [Int64]
 
-    var owner: User? { MockData.users.first { $0.id == ownerId } }
-    var paidForUsers: [User] { MockData.users.filter { paidForUserIds.contains($0.id) } }
+    var owner: User? {
+        NetworkAPIService.shared.usersCache.first { $0.id == ownerId }
+    }
+
+    var paidForUsers: [User] {
+        NetworkAPIService.shared.usersCache.filter { paidForUserIds.contains($0.id) }
+    }
 
     enum Category: String, Codable, CaseIterable {
         case tickets = "TICKETS"


### PR DESCRIPTION
## Summary
- extend `TextFieldModel` with a `title` state and update delegate rules so trip titles may contain more than two words
- load trip participants from the backend instead of using mock data
- use backend users for debts and expenses
- expose cached list of users in `NetworkAPIService`
- update view models and controllers to work with backend users

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6847bb05dafc832c9de7030765dd7e4f