### PR TITLE
Fix user list fallback for suggestions

### DIFF
--- a/T-Trips/Utils/NetworkAPIService.swift
+++ b/T-Trips/Utils/NetworkAPIService.swift
@@ -390,7 +390,9 @@ final class NetworkAPIService {
                 let users = try? JSONDecoder.apiDecoder.decode([User].self, from: data)
             else {
                 self.logError(request: request, response: response, data: data, error: error)
-                completion([])
+                let fallback = MockData.users
+                self.usersCache = fallback
+                completion(fallback)
                 return
             }
             self.usersCache = users


### PR DESCRIPTION
## Summary
- fallback to offline `MockData.users` when fetching user list fails

## Testing
- `swiftlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c7f4aa70832cb88712af3f9793f8