### PR TITLE
Add participant search alert

### DIFF
--- a/T-Trips/Localization/en.lproj/Localizable.strings
+++ b/T-Trips/Localization/en.lproj/Localizable.strings
@@ -74,3 +74,4 @@
 "tripNameTitle" = "Trip";
 "acceptButtonTitle" = "Accept";
 "rejectButtonTitle" = "Reject";
+"userNotFound" = "User not found";

--- a/T-Trips/Localization/ru.lproj/Localizable.strings
+++ b/T-Trips/Localization/ru.lproj/Localizable.strings
@@ -74,3 +74,4 @@
 "tripNameTitle" = "Поездка";
 "acceptButtonTitle" = "Принять";
 "rejectButtonTitle" = "Отклонить";
+"userNotFound" = "Пользователь не найден";

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -143,12 +143,22 @@ final class CreateTripViewController: UIViewController {
         guard !digits.isEmpty else { return }
         let phone = "+" + digits
 
-        NetworkAPIService.shared.searchUsers(query: phone) { [weak self] users in
+        NetworkAPIService.shared.findParticipant(phone: phone) { [weak self] user in
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                if let user = users.first(where: { $0.phone == phone }),
+                if let user = user,
                    !self.selectedUsers.contains(where: { $0.id == user.id }) {
                     self.addParticipant(user)
+                } else {
+                    let alert = UIAlertController(
+                        title: nil,
+                        message: String.userNotFound,
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(
+                        UIAlertAction(title: String.confirmButtonTitle, style: .default)
+                    )
+                    self.present(alert, animated: true)
                 }
             }
         }
@@ -166,4 +176,5 @@ private extension String {
     static var cancelTitle: String { "cancelButtonTitle".localized }
     static var deleteConfirmation: String { "deleteConfirmation".localized }
     static var confirmButtonTitle: String { "confirmButtonTitle".localized }
+    static var userNotFound: String { "userNotFound".localized }
 }


### PR DESCRIPTION
## Summary
- show an alert if a participant isn't found when adding to a trip
- localize the "user not found" message in English and Russian

## Testing
- `swift --version`
- `xcodebuild -list -project T-Trips.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684808ad83fc832c820806f9a116f707