### PR TITLE
Use API users for participant search

### DIFF
--- a/T-Trips/Utils/NetworkAPIService.swift
+++ b/T-Trips/Utils/NetworkAPIService.swift
@@ -351,7 +351,7 @@ final class NetworkAPIService {
     ///   - phone: Full phone number including the leading `+`.
     ///   - completion: Callback with the found user or `nil`.
     func findParticipant(phone: String, completion: @escaping (User?) -> Void) {
-        searchUsers(query: phone) { users in
+        getAllUsers { users in
             let user = users.first { $0.phone == phone }
             completion(user)
         }
@@ -377,9 +377,7 @@ final class NetworkAPIService {
                 let users = try? JSONDecoder.apiDecoder.decode([User].self, from: data)
             else {
                 self.logError(request: request, response: response, data: data, error: error)
-                let fallback = MockData.users
-                self.usersCache = fallback
-                completion(fallback)
+                completion([])
                 return
             }
             self.usersCache = users


### PR DESCRIPTION
## Summary
- look up participants in cached users
- return an empty list when `/api/v1/users` fails

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68480d8a7290832cb071097bd0c53bb7