### PR TITLE
Fix user decoding from API

### DIFF
--- a/T-Trips/Models/User.swift
+++ b/T-Trips/Models/User.swift
@@ -16,8 +16,9 @@ struct User: Codable, Identifiable {
     let lastName: String
     let hashPassword: String
     let status: Status
-    let role: Role
-    let active: Bool
+    let role: Role?
+    let active: Bool?
+    let createdAt: Date?
 
     enum Status: String, Codable, CaseIterable {
         case active = "ACTIVE"
@@ -32,11 +33,25 @@ struct User: Codable, Identifiable {
     private enum CodingKeys: String, CodingKey {
         case id
         case phone
-        case firstName
-        case lastName
-        case hashPassword
+        case firstName = "name"
+        case lastName = "surname"
+        case hashPassword = "password"
         case status
         case role
         case active
+        case createdAt = "created_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        phone = try container.decode(String.self, forKey: .phone)
+        firstName = try container.decodeIfPresent(String.self, forKey: .firstName) ?? ""
+        lastName = try container.decodeIfPresent(String.self, forKey: .lastName) ?? ""
+        hashPassword = try container.decodeIfPresent(String.self, forKey: .hashPassword) ?? ""
+        status = try container.decode(Status.self, forKey: .status)
+        role = try container.decodeIfPresent(Role.self, forKey: .role)
+        active = try container.decodeIfPresent(Bool.self, forKey: .active)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
     }
 }

--- a/T-Trips/Utils/NetworkAPIService.swift
+++ b/T-Trips/Utils/NetworkAPIService.swift
@@ -377,9 +377,7 @@ final class NetworkAPIService {
                 let users = try? JSONDecoder.apiDecoder.decode([User].self, from: data)
             else {
                 self.logError(request: request, response: response, data: data, error: error)
-                let fallback = MockData.users
-                self.usersCache = fallback
-                completion(fallback)
+                completion([])
                 return
             }
             self.usersCache = users


### PR DESCRIPTION
## Summary
- parse `/api/v1/users` response correctly by mapping backend keys
- do not load mock users on failure

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68481171f0e8832c8003fbbddfac2f65