### PR TITLE
Fix notifications dark mode color and handle leaving trips

### DIFF
--- a/T-Trips/MVVM/Main/Notifications/NotificationsView.swift
+++ b/T-Trips/MVVM/Main/Notifications/NotificationsView.swift
@@ -6,6 +6,7 @@ final class NotificationsView: UIView {
         let table = UITableView()
         table.register(CustomTableCell.self, forCellReuseIdentifier: CustomTableCell.reuseId)
         table.register(InvitationCell.self, forCellReuseIdentifier: InvitationCell.reuseId)
+        table.backgroundColor = .appBackground
         return table
     }()
 

--- a/T-Trips/MVVM/Main/Trip/TripViewController.swift
+++ b/T-Trips/MVVM/Main/Trip/TripViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import Combine
 
 final class TripViewController: UIViewController {
+    public var onTripLeft: ((Int64) -> Void)?
+
     private let tripView = TripView()
     private let viewModel: TripViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -120,8 +122,11 @@ final class TripViewController: UIViewController {
         alert.addAction(UIAlertAction(title: String.cancelTitle, style: .cancel))
         alert.addAction(
             UIAlertAction(title: String.confirmButtonTitle, style: .destructive) { [weak self] _ in
-                self?.viewModel.leaveTrip {
-                    self?.navigationController?.popViewController(animated: true)
+                guard let self = self else { return }
+                self.viewModel.leaveTrip { [weak self] in
+                    guard let self = self else { return }
+                    self.onTripLeft?(self.viewModel.trip.id)
+                    self.navigationController?.popViewController(animated: true)
                 }
             }
         )

--- a/T-Trips/MVVM/Main/Trips/TripsViewController.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewController.swift
@@ -168,8 +168,11 @@ extension TripsViewController: UITableViewDataSource, UITableViewDelegate {
         let trip = viewModel.filteredTrips[indexPath.row]
         
         let tripVM = TripViewModel(trip: trip)
-        
+
         let tripVC = TripViewController(viewModel: tripVM)
+        tripVC.onTripLeft = { [weak self] id in
+            self?.viewModel.removeTrip(id: id)
+        }
         tripVC.hidesBottomBarWhenPushed = true
 
         navigationController?.pushViewController(tripVC, animated: true)

--- a/T-Trips/MVVM/Main/Trips/TripsViewModel.swift
+++ b/T-Trips/MVVM/Main/Trips/TripsViewModel.swift
@@ -62,6 +62,10 @@ final class TripsViewModel {
     func addTrip(_ trip: Trip) {
         trips.append(trip)
     }
+
+    func removeTrip(id: Int64) {
+        trips.removeAll { $0.id == id }
+    }
 }
 
 private extension TripsViewModel.Filter {


### PR DESCRIPTION
## Summary
- match Notifications screen background with other dark mode screens
- add callback for leaving a trip so it removes the trip from the list
- update TripsViewModel to allow removing trips when user exits

## Testing
- `swift --version`
- `xcodebuild -list -project T-Trips/T-Trips.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482215d4c4832ca9ee448391b5ae06