### PR TITLE
Allow language change without logout

### DIFF
--- a/T-Trips/MVVM/Main/Settings/LanguagesViewController.swift
+++ b/T-Trips/MVVM/Main/Settings/LanguagesViewController.swift
@@ -53,7 +53,18 @@ extension LanguagesViewController: UITableViewDataSource, UITableViewDelegate {
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let delegate = scene.delegate as? SceneDelegate,
               let window = delegate.window else { return }
-        let startVC = StartViewController()
+        let startVC = StartViewController(finishAction: {
+            let mainTab = MainTabBarController()
+            mainTab.selectedIndex = 2
+            window.rootViewController = mainTab
+            window.makeKeyAndVisible()
+            UIView.transition(
+                with: window,
+                duration: .transitionDuration,
+                options: .transitionCrossDissolve,
+                animations: nil
+            )
+        })
         let nav = UINavigationController(rootViewController: startVC)
         nav.navigationBar.prefersLargeTitles = true
         window.rootViewController = nav
@@ -78,4 +89,8 @@ private extension CGFloat {
 
 private extension String {
     static var languagesTitle: String { "languages".localized }
+}
+
+private extension Double {
+    static let transitionDuration = 0.2
 }

--- a/T-Trips/MVVM/Start/StartViewController.swift
+++ b/T-Trips/MVVM/Start/StartViewController.swift
@@ -5,6 +5,16 @@ final class StartViewController: UIViewController {
     private let startView = StartView()
     private let viewModel = StartViewModel()
     private var cancellables = Set<AnyCancellable>()
+    private let finishAction: (() -> Void)?
+
+    init(finishAction: (() -> Void)? = nil) {
+        self.finishAction = finishAction
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func loadView() {
         view = startView
@@ -18,8 +28,12 @@ final class StartViewController: UIViewController {
 
     private func bindViewModel() {
         viewModel.onFinish = { [weak self] in
-            let authVC = AuthViewController()
-            self?.navigationController?.setViewControllers([authVC], animated: true)
+            if let action = self?.finishAction {
+                action()
+            } else {
+                let authVC = AuthViewController()
+                self?.navigationController?.setViewControllers([authVC], animated: true)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- customize `StartViewController` so that a closure can be passed to run after the splash screen
- after changing language, return to Settings tab instead of auth screen

## Testing
- `swift --version`
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848239ea0c8832c854e10289d98d6ee