### PR TITLE
Update keyboard dismissal and debts view background

### DIFF
--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseView.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseView.swift
@@ -47,14 +47,7 @@ final class AddExpenseView: UIView {
         return picker
     }()
     
-    private lazy var accessoryToolbar: UIToolbar = {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        let flex = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let done = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissInput))
-        toolbar.setItems([flex, done], animated: false)
-        return toolbar
-    }()
+
     
     // MARK: - UI Components
     public private(set) lazy var amountTextField: CustomTextField = {
@@ -64,7 +57,7 @@ final class AddExpenseView: UIView {
         )
         let textfield = textFieldFactory.makeTextField(with: model)
         textfield.keyboardType = .decimalPad
-        textfield.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return textfield
     }()
 
@@ -74,7 +67,7 @@ final class AddExpenseView: UIView {
             state: .name
         )
         let textfield = textFieldFactory.makeTextField(with: model)
-        textfield.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return textfield
     }()
     
@@ -85,7 +78,7 @@ final class AddExpenseView: UIView {
         )
         let textfield = textFieldFactory.makeTextField(with: model)
         textfield.inputView = datePicker
-        textfield.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return textfield
     }()
     
@@ -96,7 +89,7 @@ final class AddExpenseView: UIView {
         )
         let textfield = textFieldFactory.makeTextField(with: model)
         textfield.inputView = categoryPicker
-        textfield.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return textfield
     }()
     
@@ -107,7 +100,7 @@ final class AddExpenseView: UIView {
         )
         let textfield = textFieldFactory.makeTextField(with: model)
         textfield.inputView = payerPicker
-        textfield.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return textfield
     }()
     
@@ -117,7 +110,7 @@ final class AddExpenseView: UIView {
             state: .name
         )
         let textfield = textFieldFactory.makeTextField(with: model)
-        textfield.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return textfield
     }()
     
@@ -230,10 +223,6 @@ final class AddExpenseView: UIView {
     func updateSuggestionsHeight(_ height: CGFloat) {
         suggestionsHeightConstraint?.update(offset: height)
         layoutIfNeeded()
-    }
-    
-    @objc private func dismissInput() {
-        endEditing(true)
     }
 }
 

--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
@@ -53,6 +53,7 @@ final class AddExpenseViewController: UIViewController {
         setupPickers()
         setupSuggestions()
         setupActions()
+        dismissKeyboardOnTap()
     }
 
     // MARK: - Bindings

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
@@ -43,19 +43,12 @@ final class CreateTripView: UIView {
         return picker
     }()
 
-    private lazy var accessoryToolbar: UIToolbar = {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        let flex = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let done = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(endEditingNow))
-        toolbar.setItems([flex, done], animated: false)
-        return toolbar
-    }()
+
 
     public private(set) lazy var titleTextField: CustomTextField = {
         let model = TextFieldModel(placeholder: String.titlePlaceholder, state: .name)
         let tf = textFieldFactory.makeTextField(with: model)
-        tf.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return tf
     }()
 
@@ -63,7 +56,7 @@ final class CreateTripView: UIView {
         let model = TextFieldModel(placeholder: String.startDatePlaceholder, state: .picker)
         let tf = textFieldFactory.makeTextField(with: model)
         tf.inputView = startDatePicker
-        tf.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return tf
     }()
 
@@ -71,7 +64,7 @@ final class CreateTripView: UIView {
         let model = TextFieldModel(placeholder: String.endDatePlaceholder, state: .picker)
         let tf = textFieldFactory.makeTextField(with: model)
         tf.inputView = endDatePicker
-        tf.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return tf
     }()
 
@@ -87,14 +80,14 @@ final class CreateTripView: UIView {
         let model = TextFieldModel(placeholder: String.budgetPlaceholder, state: .money)
         let tf = textFieldFactory.makeTextField(with: model)
         tf.keyboardType = .decimalPad
-        tf.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return tf
     }()
 
     public private(set) lazy var participantsTextField: CustomTextField = {
         let model = TextFieldModel(placeholder: String.participantsPlaceholder, state: .name)
         let tf = textFieldFactory.makeTextField(with: model)
-        tf.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return tf
     }()
 
@@ -107,7 +100,7 @@ final class CreateTripView: UIView {
         tv.backgroundColor = .appBackground
         tv.textContainerInset = UIEdgeInsets.textViewPadding
         tv.isScrollEnabled = true
-        tv.inputAccessoryView = accessoryToolbar
+        // accessory view removed to dismiss via tap gesture
         return tv
     }()
 
@@ -189,10 +182,6 @@ final class CreateTripView: UIView {
     func updateSuggestionsHeight(_ height: CGFloat) {
         suggestionsHeightConstraint?.update(offset: height)
         layoutIfNeeded()
-    }
-
-    @objc private func endEditingNow() {
-        endEditing(true)
     }
 }
 

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -39,6 +39,7 @@ final class CreateTripViewController: UIViewController {
         setupPickers()
         setupSuggestions()
         setupActions()
+        dismissKeyboardOnTap()
     }
 
     private func setupBindings() {

--- a/T-Trips/MVVM/Main/Debts/DebtsView.swift
+++ b/T-Trips/MVVM/Main/Debts/DebtsView.swift
@@ -4,6 +4,7 @@ import SnapKit
 final class DebtsView: UIView {
     let tableView: UITableView = {
         let table = UITableView()
+        table.backgroundColor = .appBackground
         table.register(DebtCell.self, forCellReuseIdentifier: DebtCell.reuseId)
         return table
     }()

--- a/T-Trips/Utils/Extentions.swift
+++ b/T-Trips/Utils/Extentions.swift
@@ -70,6 +70,16 @@ extension UIColor {
     }
 }
 
+// MARK: - Keyboard dismissal
+extension UIViewController {
+    /// Hides keyboard when tapping outside of a text field.
+    func dismissKeyboardOnTap() {
+        let tap = UITapGestureRecognizer(target: view, action: #selector(UIView.endEditing))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+}
+
 // MARK: - Notification Names
 extension Notification.Name {
     static let expenseAdded = Notification.Name("expenseAdded")


### PR DESCRIPTION
## Summary
- set `tableView` background color in debts screen to match the rest of the app
- remove accessory toolbars from Create Trip and Add Expense views
- dismiss keyboards by tapping outside on Create Trip and Add Expense screens
- add helper extension for keyboard dismissal

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848292ddcdc832c93ead49a9b46f49d