### PR TITLE
Fix name length limit and adjust UI for keyboard

### DIFF
--- a/T-Trips/CustomViews/CustomTextField/CustomTextFieldDelegate.swift
+++ b/T-Trips/CustomViews/CustomTextField/CustomTextFieldDelegate.swift
@@ -35,15 +35,11 @@ final class CustomTextFieldDelegate: NSObject, UITextFieldDelegate {
             /// only letters and space are allowed
             let allowed = CharacterSet.letters.union(.whitespaces)
             guard string.rangeOfCharacter(from: allowed.inverted) == nil else { return false }
-            
+
             let prospective = (currentText as NSString).replacingCharacters(in: range, with: string)
             /// only one space in a row allowed
             if prospective.contains("  ") { return false }
-            /// not more than two words is allowd
-            let words = prospective
-                .split(separator: " ", omittingEmptySubsequences: true)
-            if words.count > 2 { return false }
-            
+
             return true
             
         case .phoneNumber:
@@ -91,17 +87,10 @@ final class CustomTextFieldDelegate: NSObject, UITextFieldDelegate {
         switch state {
         case .name:
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            let capitalized = trimmed.capitalized
-            let parts = capitalized.split(
-                separator: " ",
-                maxSplits: 1,
-                omittingEmptySubsequences: true)
-                .map(String.init)
-            let first = parts.first ?? ""
-            let last  = parts.count > 1 ? parts[1] : ""
-            textField.text = [first, last]
-                .filter { !$0.isEmpty }
-                .joined(separator: " ")
+            let components = trimmed
+                .split(separator: " ", omittingEmptySubsequences: true)
+                .map { $0.capitalized }
+            textField.text = components.joined(separator: " ")
 
         case .phoneNumber:
             /// applies formatting after leaving the TF

--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
@@ -56,6 +56,16 @@ final class AddExpenseViewController: UIViewController {
         dismissKeyboardOnTap()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        registerForKeyboardNotifications()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        unregisterFromKeyboardNotifications()
+    }
+
     // MARK: - Bindings
     private func setupBindings() {
         viewModel.$isAddEnabled

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -42,6 +42,16 @@ final class CreateTripViewController: UIViewController {
         dismissKeyboardOnTap()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        registerForKeyboardNotifications()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        unregisterFromKeyboardNotifications()
+    }
+
     private func setupBindings() {
         viewModel.$isSaveEnabled
             .receive(on: RunLoop.main)

--- a/T-Trips/Utils/Extentions.swift
+++ b/T-Trips/Utils/Extentions.swift
@@ -78,6 +78,41 @@ extension UIViewController {
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }
+
+    /// Adjusts view when keyboard appears so it doesn't cover inputs.
+    func registerForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+
+    func unregisterFromKeyboardNotifications() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard
+            let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+        else { return }
+        let inset = frame.height - view.safeAreaInsets.bottom
+        additionalSafeAreaInsets.bottom = inset
+        view.layoutIfNeeded()
+    }
+
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        additionalSafeAreaInsets.bottom = 0
+        view.layoutIfNeeded()
+    }
 }
 
 // MARK: - Notification Names


### PR DESCRIPTION
## Summary
- allow more than two words in name text fields
- keep capitalization without truncating words
- shift view up when keyboard appears using additional safe area insets
- apply keyboard adjustments in Add Expense and Create Trip screens

## Testing
- `xcodebuild -list -project T-Trips.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482d309b08832c9a035911dda03de8