### PR TITLE
Fix tokens layout on create trip screen

### DIFF
--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -152,6 +152,7 @@ final class CreateTripViewController: UIViewController {
                         token.removeFromSuperview()
                         self.createView.participantsTextField.placeholder = self.selectedUsers.isEmpty ? self.participantsPlaceholder : nil
                         self.createView.tokensView.setNeedsLayout()
+                        self.createView.layoutIfNeeded()
                     }
                 }
             )
@@ -159,6 +160,7 @@ final class CreateTripViewController: UIViewController {
         }
         createView.tokensView.addSubview(token)
         createView.tokensView.setNeedsLayout()
+        createView.layoutIfNeeded()
     }
 
     private func addParticipant(_ user: User) {


### PR DESCRIPTION
## Summary
- fix layout refresh when adding/removing participant tokens

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684834df3158832ca7f1669fd9ac0423