### PR TITLE
Fix participant suggestion selection

### DIFF
--- a/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
+++ b/T-Trips/MVVM/Main/AddExpense/AddExpenseViewController.swift
@@ -53,7 +53,7 @@ final class AddExpenseViewController: UIViewController {
         setupPickers()
         setupSuggestions()
         setupActions()
-        dismissKeyboardOnTap()
+        setupTapGesture()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -101,10 +101,6 @@ final class AddExpenseViewController: UIViewController {
         addExpenseView.payeeTextField.addAction(UIAction { [weak self] _ in
             self?.filterPayees()
         }, for: .editingChanged)
-        addExpenseView.payeeTextField.addAction(UIAction { [weak self] _ in
-            self?.addExpenseView.suggestionsTableView.isHidden = true
-            self?.addExpenseView.updateSuggestionsHeight(0)
-        }, for: .editingDidEnd)
         addExpenseView.dateTextField.addAction(
             UIAction { [weak self] _ in self?.addExpenseView.dateTextField.becomeFirstResponder() },
             for: .editingDidBegin
@@ -231,6 +227,18 @@ final class AddExpenseViewController: UIViewController {
         let height = min(CGFloat(filteredPayees.count) * 44, 132)
         addExpenseView.updateSuggestionsHeight(height)
     }
+
+    private func setupTapGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc private func handleTap() {
+        view.endEditing(true)
+        addExpenseView.suggestionsTableView.isHidden = true
+        addExpenseView.updateSuggestionsHeight(0)
+    }
 }
 
 // MARK: - UIPickerViewDataSource & UIPickerViewDelegate
@@ -281,6 +289,7 @@ extension AddExpenseViewController: UITableViewDataSource, UITableViewDelegate {
         filteredPayees.removeAll()
         addExpenseView.suggestionsTableView.isHidden = true
         addExpenseView.updateSuggestionsHeight(0)
+        addExpenseView.payeeTextField.resignFirstResponder()
         addPayee(user)
         addExpenseView.suggestionsTableView.reloadData()
     }

--- a/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -39,7 +39,7 @@ final class CreateTripViewController: UIViewController {
         setupPickers()
         setupSuggestions()
         setupActions()
-        dismissKeyboardOnTap()
+        setupTapGesture()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -118,10 +118,6 @@ final class CreateTripViewController: UIViewController {
             self?.filterParticipants()
         }, for: .editingChanged)
       
-        createView.participantsTextField.addAction(UIAction { [weak self] _ in
-            self?.createView.suggestionsTableView.isHidden = true
-            self?.createView.updateSuggestionsHeight(0)
-        }, for: .editingDidEnd)
 
         createView.saveButton.addAction(UIAction { [weak self] _ in
             self?.viewModel.saveTrip()
@@ -189,6 +185,18 @@ final class CreateTripViewController: UIViewController {
         let height = min(CGFloat(filteredParticipants.count) * 44, 132)
         createView.updateSuggestionsHeight(height)
     }
+
+    private func setupTapGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc private func handleTap() {
+        view.endEditing(true)
+        createView.suggestionsTableView.isHidden = true
+        createView.updateSuggestionsHeight(0)
+    }
 }
 
 extension CreateTripViewController: UITableViewDataSource, UITableViewDelegate {
@@ -210,6 +218,7 @@ extension CreateTripViewController: UITableViewDataSource, UITableViewDelegate {
         filteredParticipants.removeAll()
         createView.suggestionsTableView.isHidden = true
         createView.updateSuggestionsHeight(0)
+        createView.participantsTextField.resignFirstResponder()
         addParticipant(user)
         createView.suggestionsTableView.reloadData()
     }


### PR DESCRIPTION
## Summary
- hide suggestion tables after tap using new gesture handlers
- dismiss keyboard on selection for trip participants
- dismiss keyboard on selection for expense payees

## Testing
- `apt-get update`
- `apt-get install -y swiftlint` *(fails: package not found)*
- `curl -L -o /tmp/swiftlint.zip https://github.com/realm/SwiftLint/releases/download/0.53.0/portable_swiftlint.zip`
- `unzip -o /tmp/swiftlint.zip -d /tmp/swiftlint`
- `install /tmp/swiftlint/swiftlint /usr/local/bin/swiftlint`
- `swiftlint` *(fails: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_684ec9392728832c9a3c4522a0fbaec2